### PR TITLE
Fix 404 page being included in sitemap

### DIFF
--- a/.github/workflows/generate-sitemap.yml
+++ b/.github/workflows/generate-sitemap.yml
@@ -23,6 +23,9 @@ jobs:
           include-pdf: false
           drop-html-extension: false
           date-only: true
+          exclude-paths: >
+            /404.html
+            /search-results.html
 
       - name: Install xmlstarlet
         run: |


### PR DESCRIPTION
## Summary
- exclude the 404 and search-results pages when generating sitemap.xml

## Testing
- `npx prettier -c .github/workflows/generate-sitemap.yml`
- `yamllint .github/workflows/generate-sitemap.yml`

------
https://chatgpt.com/codex/tasks/task_e_686f9d69e30883299aa21c4f951daa36