### PR TITLE
Fix sitemap generation to ignore .git

### DIFF
--- a/.github/workflows/generate-sitemap.yml
+++ b/.github/workflows/generate-sitemap.yml
@@ -26,6 +26,7 @@ jobs:
           exclude-paths: >
             /404.html
             /search-results.html
+            /.git/**
 
       - name: Install xmlstarlet
         run: |

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -75,7 +75,3 @@ https://exitfloridakeys.com/articles/visit-earth-extremities.html
 https://exitfloridakeys.com/articles/voluntourism-impactful-travel.html
 https://exitfloridakeys.com/articles/voyage-through-vineyards-global-wine-regions.html
 https://exitfloridakeys.com/product/flagyl.html
-https://exitfloridakeys.com/.git/refs/heads/codex/add-noindex-meta-tag-to-search-results.html
-https://exitfloridakeys.com/.git/logs/refs/heads/codex/add-noindex-meta-tag-to-search-results.html
-https://exitfloridakeys.com/.git/refs/remotes/origin/codex/add-noindex-meta-tag-to-search-results.html
-https://exitfloridakeys.com/.git/logs/refs/remotes/origin/codex/add-noindex-meta-tag-to-search-results.html

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -308,20 +308,4 @@
     <loc>https://exitfloridakeys.com/product/flagyl.html</loc>
     <lastmod>2025-06-26</lastmod>
   </url>
-  <url>
-    <loc>https://exitfloridakeys.com/.git/refs/heads/codex/add-noindex-meta-tag-to-search-results.html</loc>
-    <lastmod>2025-07-10</lastmod>
-  </url>
-  <url>
-    <loc>https://exitfloridakeys.com/.git/logs/refs/heads/codex/add-noindex-meta-tag-to-search-results.html</loc>
-    <lastmod>2025-07-10</lastmod>
-  </url>
-  <url>
-    <loc>https://exitfloridakeys.com/.git/refs/remotes/origin/codex/add-noindex-meta-tag-to-search-results.html</loc>
-    <lastmod>2025-07-10</lastmod>
-  </url>
-  <url>
-    <loc>https://exitfloridakeys.com/.git/logs/refs/remotes/origin/codex/add-noindex-meta-tag-to-search-results.html</loc>
-    <lastmod>2025-07-10</lastmod>
-  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- exclude `.git` directory from generated sitemap
- remove erroneous sitemap entries referencing `.git`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687f78584b588329a4b7924d462b6fd1