### PR TITLE
fix: strip branding prefix from search index titles

### DIFF
--- a/assets/search.json
+++ b/assets/search.json
@@ -88,7 +88,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1504598318550-17eba1008a68?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxkaWdpdGFsJTIwbm9tYWQlMkMlMjByZW1vdGUlMjB3b3JrJTJDJTIwdHJhdmVsJTJDJTIwd29ybGQlMjBleHBsb3JhdGlvbiUyQyUyMGxhcHRvcCUyMG91dGRvb3JzfGVufDB8fHx8MTc0NTQ0MzAwNHww&ixlib=rb-4.0.3&q=80&w=200&h=75"
   },
   {
-    "title": "Audio Travel Guide | Discover Transformative Travel Stories and Top Trending Destinations",
+    "title": "Discover Transformative Travel Stories and Top Trending Destinations",
     "url": "/articles/discover-transformative-travel-stories-trending-destinations.html",
     "imageAlt": "the word travel spelled with scrabbles on a wooden table",
     "description": "Transformative travel stories reveal how exploring new destinations can spark personal growth and unforgettable adventures. Let’s dive into how embracing these experiences can change your perspective and explore the top trending travel destinations for 2025.",
@@ -128,7 +128,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1669399554927-cc38ca6bc3ba?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlbmNoYW50aW5nJTIwdHJhdmVsJTIwZGVzdGluYXRpb25zJTIwMjAyNXxlbnwwfDB8fHwxNzU1MjYyODM2fDA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
   },
   {
-    "title": "Audio Travel Guide | Explore Unique Travel Experiences and Hidden Gems in 2025",
+    "title": "Explore Unique Travel Experiences and Hidden Gems in 2025",
     "url": "/articles/explore-unique-travel-experiences-hidden-gems-2025.html",
     "imageAlt": "black Nipa huts during daytime",
     "description": "2025 promises a fresh wave of unique travel experiences that will ignite your wanderlust and reveal captivating hidden gems. Dive into thrilling adventures and off-the-beaten-path discoveries as we explore top travel destinations and essential tips for every traveler.",
@@ -168,7 +168,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1659709695768-1f4b79290b78?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBsb2NhbCUyMGZlc3RpdmFscyUyMHVuaXF1ZSUyMHRyYXZlbCUyMGhvYmJpZXMlMjBvdXRkb29yJTIwYWN0aXZpdGllc3xlbnwwfDB8fHwxNzUwMTg5ODEwfDA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
   },
   {
-    "title": "Audio Travel Guide | Exploring New Horizons: Top Travel Tips and Destinations for 2025",
+    "title": "Exploring New Horizons: Top Travel Tips and Destinations for 2025",
     "url": "/articles/exploring-new-horizons-top-travel-tips-destinations-2025.html",
     "imageAlt": "null",
     "description": "2025 is shaping up to be an exciting year for travel enthusiasts eager to explore new horizons and create unforgettable memories. Let's dive into essential travel tips that will prepare you for your next adventure and uncover the best destinations waiting for you to explore.",
@@ -200,7 +200,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1527576539890-dfa815648363?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxVTkVTQ08lMjBXb3JsZCUyMEhlcml0YWdlJTIwU2l0ZXMlMkMlMjBoaXN0b3JpY2FsJTIwbGFuZG1hcmtzJTJDJTIwY3VsdHVyYWwlMjBoZXJpdGFnZSUyQyUyMHRyYXZlbCUyMHBob3RvZ3JhcGh5JTJDJTIwYW5jaWVudCUyMGFyY2hpdGVjdHVyZXxlbnwwfHx8fDE3NDU0NDMwNDJ8MA&ixlib=rb-4.0.3&q=80&w=200&h=75"
   },
   {
-    "title": "Audio Travel Guide | Exploring Unique Destinations and Travel Experiences Worldwide in 2025",
+    "title": "Exploring Unique Destinations and Travel Experiences Worldwide in 2025",
     "url": "/articles/exploring-unique-destinations-travel-experiences-2025.html",
     "imageAlt": "brown house on mountain",
     "description": "Discover the thrill of exploring unique destinations and travel experiences worldwide in 2025 that promise unforgettable memories. From bucket-list adventures to hidden gems, this guide will inspire your next journey and lead you to seamless and authentic travel.",
@@ -272,7 +272,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1725137752276-c273686fc3c4?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxoaXN0b3JpYyUyMHJhaWx3YXklMjB0cmFpbiUyMGxhbmRzY2FwZXxlbnwwfHx8fDE3NDUyNzA2NTZ8MA&ixlib=rb-4.0.3&q=80&w=200&h=75"
   },
   {
-    "title": "Audio Travel Guide | Top Inspiring Travel Destinations and Tips for 2025 Adventures",
+    "title": "Top Inspiring Travel Destinations and Tips for 2025 Adventures",
     "url": "/articles/inspiring-travel-destinations-tips-2025-adventures.html",
     "imageAlt": "a group of people standing around a body of water",
     "description": "Discover the most inspiring travel destinations for 2025 that promise unforgettable adventures and personal growth. Let’s dive into top locations and essential tips to boost your confidence, perfect your itinerary, and stay safe while exploring.",
@@ -312,7 +312,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1570790317302-b041629421f2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxmdXR1cmlzdGljJTIwdHJhdmVsJTIwc2NlbmVzfGVufDB8MHx8fDE3NTA1MDAwNDV8MA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
   },
   {
-    "title": "Audio Travel Guide | Navigating Modern Travel: Safety, Culture, and Unique Destinations in 2025",
+    "title": "Navigating Modern Travel: Safety, Culture, and Unique Destinations in 2025",
     "url": "/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html",
     "imageAlt": "a group of people walking down a hallway",
     "description": "Modern travel in 2025 presents new challenges and exciting opportunities that require careful planning. From ensuring safety to embracing cultural immersion, this guide begins with essential travel safety tips for a secure journey.",
@@ -320,7 +320,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1647161407063-d49d91a5e6b8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHklMjBjdWx0dXJhbCUyMGRpdmVyc2l0eSUyMHVuaXF1ZSUyMGRlc3RpbmF0aW9ucyUyMDIwMjV8ZW58MHwwfHx8MTc1MTk2ODg1OXww&ixlib=rb-4.1.0&q=80&w=1080?w=200"
   },
   {
-    "title": "Audio Travel Guide | Navigating Modern Travel: Safety Tips, Destinations, and Experiences",
+    "title": "Navigating Modern Travel: Safety Tips, Destinations, and Experiences",
     "url": "/articles/navigating-modern-travel-safety-tips-destinations-experiences.html",
     "imageAlt": "a traffic light on a pole with a sky background",
     "description": "Navigating modern travel requires a balance of excitement and caution as new challenges and opportunities arise. This guide will equip you with essential safety tips and practical advice to handle disruptions, empowering you to explore top destinations with confidence.",
@@ -336,7 +336,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1473093295043-cdd812d0e601?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxuaWdodCUyMG1hcmtldCUyMGZvb2QlMjBzdHJlZXQlMjBBc2lhJTIwY29sb3JmdWwlMjBzdGFsbHN8ZW58MHx8fHwxNzQ1MzM3OTYyfDA&ixlib=rb-4.0.3&q=80&w=200&h=75"
   },
   {
-    "title": "Audio Travel Guide | Navigating Realities and Wonders of Modern Travel in 2025",
+    "title": "Navigating Realities and Wonders of Modern Travel in 2025",
     "url": "/articles/navigating-realities-wonders-modern-travel-2025.html",
     "imageAlt": "A long hallway in a building with lights on",
     "description": "The landscape of travel in 2025 offers a blend of awe-inspiring destinations and complex challenges that modern explorers must navigate. Understanding these dynamics sets the stage for discovering unique places and handling the realities of contemporary travel.",
@@ -344,7 +344,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1727673108412-aaea551e6e7a?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxmdXR1cmlzdGljJTIwdHJhdmVsJTIwaHVic3xlbnwwfDB8fHwxNzUxMTkxMjYzfDA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
   },
   {
-    "title": "Audio Travel Guide | Navigating Solo Journeys and Travel Challenges in 2025",
+    "title": "Navigating Solo Journeys and Travel Challenges in 2025",
     "url": "/articles/navigating-solo-journeys-travel-challenges-2025.html",
     "imageAlt": "person carrying yellow and black backpack walking between green plants",
     "description": "Solo travel in 2025 presents unique opportunities and challenges that require thoughtful preparation and awareness. This guide covers essential tips, safety priorities, layover optimization, and strategies for overcoming common travel obstacles to help you navigate your journey confidently.",
@@ -352,7 +352,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1501555088652-021faa106b9b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxzb2xvJTIwdHJhdmVsZXJ8ZW58MHwwfHx8MTc1MTQ1MDQ3Mnww&ixlib=rb-4.1.0&q=80&w=1080?w=200"
   },
   {
-    "title": "Audio Travel Guide | Navigating Travel Experiences: Tips, Challenges, and Inspiring Journeys",
+    "title": "Navigating Travel Experiences: Tips, Challenges, and Inspiring Journeys",
     "url": "/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html",
     "imageAlt": "a car driving down a dirt road in the mountains",
     "description": "Travel opens doors to diverse cultures and unforgettable experiences, but it also presents unique challenges along the way. This article delves into essential travel tips that ensure smoother journeys and prepares you to overcome common obstacles with confidence.",
@@ -528,7 +528,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1695313486156-469b82f59e07?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxmYW1pbHklMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUwNTQzNTA0fDA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
   },
   {
-    "title": "Audio Travel Guide | Ultimate Travel Guide: Tips, Destinations, and Insider Experiences for 2025",
+    "title": "Ultimate Travel Guide: Tips, Destinations, and Insider Experiences for 2025",
     "url": "/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html",
     "imageAlt": "aerial photography of body of water during daytime",
     "description": "Get ready to unlock the secrets of unforgettable adventures with our Ultimate Travel Guide for 2025, packed with tips, top destinations, and insider experiences. From expert advice to exciting places, let’s dive into essential travel tips that will elevate your next journey.",
@@ -536,7 +536,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1520285774798-2f1616131a68?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxsdXh1cnklMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnMlMjAyMDI1fGVufDB8MHx8fDE3NTE4ODI0NDN8MA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
   },
   {
-    "title": "Audio Travel Guide | Unexpected Journeys and Realities: Exploring Modern Travel Experiences",
+    "title": "Unexpected Journeys and Realities: Exploring Modern Travel Experiences",
     "url": "/articles/unexpected-journeys-realities-modern-travel-experiences.html",
     "imageAlt": "man wearing white shirt overlooking on white clouds",
     "description": "Modern travel often brings unexpected challenges and unique experiences that redefine our journeys. Navigating airport stories and travel realities sets the stage for uncovering hidden gems and essential tips for safer trips.",
@@ -544,7 +544,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1552207311-2d6d6e8f1bd2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTE0OTM2NjB8MA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
   },
   {
-    "title": "Audio Travel Guide | Unforgettable Travel Adventures: Exploring Unique Destinations Safely",
+    "title": "Unforgettable Travel Adventures: Exploring Unique Destinations Safely",
     "url": "/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html",
     "imageAlt": "A large brick building sitting on top of a dry grass field",
     "description": "Escape the usual tourist trails and immerse yourself in unforgettable travel adventures that celebrate unique destinations. Let’s embark on a journey to discover exclusive experiences while ensuring your safety every step of the way.",
@@ -560,7 +560,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1634864221446-d7f305974814?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwbW91bnRhaW4lMjBsYW5kc2NhcGVzfGVufDB8MHx8fDE3NTM2MTc4Nzh8MA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
   },
   {
-    "title": "Audio Travel Guide | Unforgettable Travel Experiences and Top Destinations in 2025",
+    "title": "Unforgettable Travel Experiences and Top Destinations in 2025",
     "url": "/articles/unforgettable-travel-experiences-top-destinations-2025.html",
     "imageAlt": "photo of assorted-color air balloon lot in mid air during daytime",
     "description": "Get ready to explore the most inspiring travel destinations of 2025 that promise unforgettable adventures and lasting memories. This guide will equip you with expert planning tips, essential safety advice, and creative ideas to make every trip extraordinary.",
@@ -576,7 +576,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1609464528647-bd84b5b6b461?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxleG90aWMlMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnN8ZW58MHwwfHx8MTc1NTI0NDcyMnww&ixlib=rb-4.1.0&q=80&w=1080?w=200"
   },
   {
-    "title": "Audio Travel Guide | Unforgettable Travel Stories and Expert Tips for 2025 Adventures",
+    "title": "Unforgettable Travel Stories and Expert Tips for 2025 Adventures",
     "url": "/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html",
     "imageAlt": "people standing on brown sand under blue sky during daytime",
     "description": "Unforgettable travel stories ignite the passion for exploring new horizons, offering inspiration for your 2025 adventures. Dive into remarkable experiences and expert tips that set the stage for safe, culturally rich journeys ahead.",
@@ -584,7 +584,7 @@
     "imageUrl": "https://images.unsplash.com/photo-1608984075444-0e67cd80f696?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwdHJhdmVsJTIwbGFuZHNjYXBlc3xlbnwwfDB8fHwxNzUxODM5MjUyfDA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
   },
   {
-    "title": "Audio Travel Guide | Unplanned Journeys and Travel Realities: Insights for Savvy Adventurers",
+    "title": "Unplanned Journeys and Travel Realities: Insights for Savvy Adventurers",
     "url": "/articles/unplanned-journeys-travel-realities-insights.html",
     "imageAlt": "a man pushing a cart full of bags down a street",
     "description": "Travel often leads us down unexpected paths, revealing the true nature of unplanned journeys and travel realities. This article dives into embracing surprise destinations and mastering the practical challenges that come with them.",

--- a/scripts/update-search-index.mjs
+++ b/scripts/update-search-index.mjs
@@ -10,7 +10,8 @@ const index = [];
 for (const file of files) {
   const html = await readFile(join(articlesDir, file), 'utf8');
 
-  const title = html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"]+)["'][^>]*>/i)?.[1] || '';
+  let title = html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"]+)["'][^>]*>/i)?.[1] || '';
+  title = title.replace(/^Audio Travel Guide \|\s*/, '');
   const descMatch = html.match(/<p[^>]*itemprop=["']description["'][^>]*>([\s\S]*?)<\/p>/i);
   const description = descMatch ? descMatch[1].replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim() : '';
   const publishDate = html.match(/<time[^>]*datetime=["']([^"]+)["']/i)?.[1] || '';


### PR DESCRIPTION
## Summary
- trim `Audio Travel Guide |` prefix from titles when building search index
- regenerate search index with cleaned titles

## Testing
- `node scripts/update-search-index.mjs`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f420be37c8329a28d390c6e238b37