### PR TITLE
feat: add AdSense block to article pages

### DIFF
--- a/articles/african-safari-experience-a-journey-into-the-wild.html
+++ b/articles/african-safari-experience-a-journey-into-the-wild.html
@@ -199,6 +199,17 @@
             truly unforgettable.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/architectural-marvels-modern-wonders-world.html
+++ b/articles/architectural-marvels-modern-wonders-world.html
@@ -204,6 +204,17 @@
             stories behind their construction and what makes them extraordinary.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/behind-scenes-worlds-largest-festivals.html
+++ b/articles/behind-scenes-worlds-largest-festivals.html
@@ -204,6 +204,17 @@
             hidden behind the glamour.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/best-safari-destinations.html
+++ b/articles/best-safari-destinations.html
@@ -205,6 +205,17 @@
             wilderness areas around the globe.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/best-travel-apps.html
+++ b/articles/best-travel-apps.html
@@ -195,6 +195,17 @@
           </p>
         </header>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/beyond-hostels-hotels-unique-accommodations-adventurous-traveler.html
+++ b/articles/beyond-hostels-hotels-unique-accommodations-adventurous-traveler.html
@@ -204,6 +204,17 @@
           </p>
         </header>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/chasing-northern-lights-best-places.html
+++ b/articles/chasing-northern-lights-best-places.html
@@ -204,6 +204,17 @@
             an unforgettable experience beneath the vibrant, dancing skies.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/culinary-trails-origins-iconic-street-food.html
+++ b/articles/culinary-trails-origins-iconic-street-food.html
@@ -202,6 +202,17 @@
             lovers to embark on a tasty journey through history and culture.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/cultural-immersion-experiences.html
+++ b/articles/cultural-immersion-experiences.html
@@ -199,6 +199,17 @@
             resonate with the place’s soul.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/dark-tourism-worlds-haunting-locations.html
+++ b/articles/dark-tourism-worlds-haunting-locations.html
@@ -201,6 +201,17 @@
             human curiosity that draws visitors in for a haunting experience.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/digital-nomad-life-world.html
+++ b/articles/digital-nomad-life-world.html
@@ -203,6 +203,17 @@
             adventure.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/discover-transformative-travel-stories-trending-destinations.html
+++ b/articles/discover-transformative-travel-stories-trending-destinations.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">Transformative travel stories reveal how exploring new destinations can spark personal growth and unforgettable adventures. Let’s dive into how embracing these experiences can change your perspective and explore the top trending travel destinations for 2025.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1673515335086-c762bbd7a7cf?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx0cmFuc2Zvcm1hdGl2ZSUyMHRyYXZlbCUyMGV4cGVyaWVuY2V8ZW58MHwwfHx8MTc1MTcwOTY1NHww&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/discovering-underwater-world-best-snorkeling-spots-globally.html
+++ b/articles/discovering-underwater-world-best-snorkeling-spots-globally.html
@@ -192,6 +192,17 @@
             levels.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/eco-friendly-traveling-world-sustainably.html
+++ b/articles/eco-friendly-traveling-world-sustainably.html
@@ -198,6 +198,17 @@
           impacts.
         </p>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/embracing-eco-tourism-sustainable-journey-costa-rica.html
+++ b/articles/embracing-eco-tourism-sustainable-journey-costa-rica.html
@@ -200,6 +200,17 @@
             economies.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/explore-enchanting-destinations-smart-travel-planning-2025.html
+++ b/articles/explore-enchanting-destinations-smart-travel-planning-2025.html
@@ -152,6 +152,17 @@
 </div>
   <p itemprop="description">Discover the most enchanting travel destinations set to captivate adventurers in 2025, paired with smart planning tips to make every trip seamless. From unique locales to insider advice, this guide will inspire your next unforgettable journey.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1669399554927-cc38ca6bc3ba?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlbmNoYW50aW5nJTIwdHJhdmVsJTIwZGVzdGluYXRpb25zJTIwMjAyNXxlbnwwfDB8fHwxNzU1MjYyODM2fDA&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/explore-unique-travel-experiences-hidden-gems-2025.html
+++ b/articles/explore-unique-travel-experiences-hidden-gems-2025.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">2025 promises a fresh wave of unique travel experiences that will ignite your wanderlust and reveal captivating hidden gems. Dive into thrilling adventures and off-the-beaten-path discoveries as we explore top travel destinations and essential tips for every traveler.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1578019448201-09ad2ac7995a?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxyZW1vdGUlMjB2aWxsYWdlJTIwaGlkZGVuJTIwcGFyYWRpc2V8ZW58MHwwfHx8MTc1MTIzNDcxNHww&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/exploring-arctic-travel-guide.html
+++ b/articles/exploring-arctic-travel-guide.html
@@ -208,6 +208,17 @@
           </p>
         </header>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/exploring-authentic-travel-experiences-hidden-gems-challenges.html
+++ b/articles/exploring-authentic-travel-experiences-hidden-gems-challenges.html
@@ -204,6 +204,17 @@
           connections set the stage for unforgettable adventures.
         </p>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/exploring-emerging-travel-trends-and-unique-hobby-inspirations.html
+++ b/articles/exploring-emerging-travel-trends-and-unique-hobby-inspirations.html
@@ -202,6 +202,17 @@
         emerging travel trends and uncover unique hobbies that can transform
         your next adventure into a truly memorable experience.
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/exploring-emerging-travel-trends-unique-hobby-inspirations.html
+++ b/articles/exploring-emerging-travel-trends-unique-hobby-inspirations.html
@@ -200,6 +200,17 @@
         destinations to unique hobbies that enrich journeys, let’s delve into
         what’s shaping the future of travel.
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/exploring-new-horizons-top-travel-tips-destinations-2025.html
+++ b/articles/exploring-new-horizons-top-travel-tips-destinations-2025.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">2025 is shaping up to be an exciting year for travel enthusiasts eager to explore new horizons and create unforgettable memories. Let's dive into essential travel tips that will prepare you for your next adventure and uncover the best destinations waiting for you to explore.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1477346433521-912858ffd498?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb3VudGFpbiUyMHN1bnJpc2UlMjBhZHZlbnR1cmV8ZW58MHwwfHx8MTc1MTkyNTc5NHww&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/exploring-scottish-highlands.html
+++ b/articles/exploring-scottish-highlands.html
@@ -202,6 +202,17 @@
             everyone.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/exploring-trending-travel-destinations-and-relaxing-hobby-ideas.html
+++ b/articles/exploring-trending-travel-destinations-and-relaxing-hobby-ideas.html
@@ -198,6 +198,17 @@
           complement your journeys perfectly.
         </p>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/exploring-unesco-sites.html
+++ b/articles/exploring-unesco-sites.html
@@ -206,6 +206,17 @@
             sites around the globe, uncovering their secrets and significance.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/exploring-unique-destinations-travel-experiences-2025.html
+++ b/articles/exploring-unique-destinations-travel-experiences-2025.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">Discover the thrill of exploring unique destinations and travel experiences worldwide in 2025 that promise unforgettable memories. From bucket-list adventures to hidden gems, this guide will inspire your next journey and lead you to seamless and authentic travel.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1512818908771-583ff7531c14?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxoaWRkZW4lMjByZW1vdGUlMjBkZXN0aW5hdGlvbnN8ZW58MHwwfHx8MTc1MDg4ODg1NHww&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/exploring-untouched-forests.html
+++ b/articles/exploring-untouched-forests.html
@@ -201,6 +201,17 @@
             worth protecting for generations to come.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/exploring-worlds-historical-walking-routes.html
+++ b/articles/exploring-worlds-historical-walking-routes.html
@@ -202,6 +202,17 @@
             unique insights into our collective past.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/exploring-worlds-most-religious-sites.html
+++ b/articles/exploring-worlds-most-religious-sites.html
@@ -203,6 +203,17 @@
             own sacred journey.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/glamping-world-luxury-tents-incredible-views.html
+++ b/articles/glamping-world-luxury-tents-incredible-views.html
@@ -204,6 +204,17 @@
             adventures.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/global-gastronomy-tasting-traditional-dishes-different-cultures.html
+++ b/articles/global-gastronomy-tasting-traditional-dishes-different-cultures.html
@@ -204,6 +204,17 @@
             and the rich tapestry of cultural diversity reflected in food.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/going-green-vegan-vegetarian-travel.html
+++ b/articles/going-green-vegan-vegetarian-travel.html
@@ -204,6 +204,17 @@
             exciting trend for eco-aware adventurers.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/hidden-gems-uncharted-travel-destinations.html
+++ b/articles/hidden-gems-uncharted-travel-destinations.html
@@ -197,6 +197,17 @@
           you may not even know existed but will never forget.
         </p>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/historic-railways-world-journey.html
+++ b/articles/historic-railways-world-journey.html
@@ -202,6 +202,17 @@
             enduring legacy.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/inspiring-travel-destinations-tips-2025-adventures.html
+++ b/articles/inspiring-travel-destinations-tips-2025-adventures.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">Discover the most inspiring travel destinations for 2025 that promise unforgettable adventures and personal growth. Let’s dive into top locations and essential tips to boost your confidence, perfect your itinerary, and stay safe while exploring.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1685703710232-2b2045b2434f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxicmVhdGh0YWtpbmclMjB0cmF2ZWwlMjBsYW5kc2NhcGVzfGVufDB8MHx8fDE3NTE0MDc1NDB8MA&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/navigating-complexities-of-travel-tips-tales-realities.html
+++ b/articles/navigating-complexities-of-travel-tips-tales-realities.html
@@ -202,6 +202,17 @@
           help you navigate your journeys with confidence.
         </p>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html
+++ b/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html
@@ -152,6 +152,17 @@
 </div>
   <p itemprop="description">Global travel invites explorers to venture beyond typical tourist spots, uncovering unique destinations rich in culture and challenge. This journey begins by exploring off-the-beaten-path locations that reveal authentic experiences and set the stage for meaningful adventures.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1560643248-d9c6124b2a44?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3aW5kaW5nJTIwbW91bnRhaW4lMjByb2FkcyUyMHJlbW90ZSUyMHZpbGxhZ2UlMjBjdWx0dXJhbCUyMGZlc3RpdmFsfGVufDB8MHx8fDE3NTMxOTAwNzR8MA&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html
+++ b/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html
@@ -152,6 +152,17 @@
 </div>
   <p itemprop="description">Navigating the world of modern travel introduces a mix of exciting experiences and unexpected challenges. This article begins by exploring key travel experiences in 2025 that set the stage for contemporary journeys.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1552207311-2d6d6e8f1bd2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTUyNjI0OTJ8MA&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/navigating-modern-travel-insights-experiences-tips-2025.html
+++ b/articles/navigating-modern-travel-insights-experiences-tips-2025.html
@@ -199,6 +199,17 @@
           delays, solo journeys, and curated European itineraries seamlessly.
         </p>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html
+++ b/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">Modern travel in 2025 presents new challenges and exciting opportunities that require careful planning. From ensuring safety to embracing cultural immersion, this guide begins with essential travel safety tips for a secure journey.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1647161407063-d49d91a5e6b8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHklMjBjdWx0dXJhbCUyMGRpdmVyc2l0eSUyMHVuaXF1ZSUyMGRlc3RpbmF0aW9ucyUyMDIwMjV8ZW58MHwwfHx8MTc1MTk2ODg1OXww&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/navigating-modern-travel-safety-tips-destinations-experiences.html
+++ b/articles/navigating-modern-travel-safety-tips-destinations-experiences.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">Navigating modern travel requires a balance of excitement and caution as new challenges and opportunities arise. This guide will equip you with essential safety tips and practical advice to handle disruptions, empowering you to explore top destinations with confidence.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1718242869012-34c2587f50aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHl8ZW58MHwwfHx8MTc1MjA3OTU0Mnww&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/navigating-night-markets-food-lovers-guide.html
+++ b/articles/navigating-night-markets-food-lovers-guide.html
@@ -203,6 +203,17 @@
             food destinations.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/navigating-realities-wonders-modern-travel-2025.html
+++ b/articles/navigating-realities-wonders-modern-travel-2025.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">The landscape of travel in 2025 offers a blend of awe-inspiring destinations and complex challenges that modern explorers must navigate. Understanding these dynamics sets the stage for discovering unique places and handling the realities of contemporary travel.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1727673108412-aaea551e6e7a?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxmdXR1cmlzdGljJTIwdHJhdmVsJTIwaHVic3xlbnwwfDB8fHwxNzUxMTkxMjYzfDA&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/navigating-solo-journeys-travel-challenges-2025.html
+++ b/articles/navigating-solo-journeys-travel-challenges-2025.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">Solo travel in 2025 presents unique opportunities and challenges that require thoughtful preparation and awareness. This guide covers essential tips, safety priorities, layover optimization, and strategies for overcoming common travel obstacles to help you navigate your journey confidently.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1501555088652-021faa106b9b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxzb2xvJTIwdHJhdmVsZXJ8ZW58MHwwfHx8MTc1MTQ1MDQ3Mnww&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html
+++ b/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">Travel opens doors to diverse cultures and unforgettable experiences, but it also presents unique challenges along the way. This article delves into essential travel tips that ensure smoother journeys and prepares you to overcome common obstacles with confidence.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1643889037313-7bda0ccc3d69?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3YW5kZXJsdXN0JTIwcm9hZCUyMHRyaXAlMjBzY2VuaWMlMjBsYW5kc2NhcGVzJTIwY3VsdHVyYWwlMjBpbW1lcnNpb258ZW58MHwwfHx8MTc1MTEwNTA3N3ww&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/pedal-paradises-destinations-cycling-enthusiasts.html
+++ b/articles/pedal-paradises-destinations-cycling-enthusiasts.html
@@ -203,6 +203,17 @@
             memorable adventures on two wheels.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/river-cruises-europe.html
+++ b/articles/river-cruises-europe.html
@@ -200,6 +200,17 @@
             authentic local encounters.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/roaming-roof-world-himalayas-guide.html
+++ b/articles/roaming-roof-world-himalayas-guide.html
@@ -199,6 +199,17 @@
             the grandeur of the world's highest mountain range.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/sanctuaries-sky-worlds-picturesque-mountain-retreats.html
+++ b/articles/sanctuaries-sky-worlds-picturesque-mountain-retreats.html
@@ -204,6 +204,17 @@
             serene mountain havens around the world.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/solo-travel-guide-southeast-asia-safety.html
+++ b/articles/solo-travel-guide-southeast-asia-safety.html
@@ -199,6 +199,17 @@
           your adventure is smooth, enriching, and fun.
         </p>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/solo-travel-safety-guide.html
+++ b/articles/solo-travel-safety-guide.html
@@ -190,6 +190,17 @@
             unexpected situations.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/sustainable-food-explorations.html
+++ b/articles/sustainable-food-explorations.html
@@ -200,6 +200,17 @@
             meaningful and responsible travel experiences.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/timeless-timelines-history-iconic-landmarks.html
+++ b/articles/timeless-timelines-history-iconic-landmarks.html
@@ -202,6 +202,17 @@
             enduring allure that make them timeless symbols around the globe.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/top-10-hidden-gems-europe.html
+++ b/articles/top-10-hidden-gems-europe.html
@@ -192,6 +192,17 @@
           </p>
         </header>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: crop exactly 1080×400 at 100% JPEG quality -->

--- a/articles/top-surfing-destinations-world.html
+++ b/articles/top-surfing-destinations-world.html
@@ -187,6 +187,17 @@
             surfers alike to chase the waves.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/touring-tropics-comprehensive-guide.html
+++ b/articles/touring-tropics-comprehensive-guide.html
@@ -204,6 +204,17 @@
             for tropical travel.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/transcontinental-trails-world.html
+++ b/articles/transcontinental-trails-world.html
@@ -203,6 +203,17 @@
             globe.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/travel-budget-tips.html
+++ b/articles/travel-budget-tips.html
@@ -193,6 +193,17 @@
           </p>
         </header>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html
+++ b/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html
@@ -152,6 +152,17 @@
 </div>
   <p itemprop="description">Mastering travel flexibility unlocks thrilling adventures and opens the door to unforgettable experiences. Let’s dive into embracing unpredictability and start with how flexibility fuels adventurous journeys.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1503220954697-e02095e8e0d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUzNjE3MzIxfDA&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/travel-hacks-tips-save-money-time.html
+++ b/articles/travel-hacks-tips-save-money-time.html
@@ -199,6 +199,17 @@
           of every journey, from planning to exploring new destinations.
         </p>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/traveling-silk-road.html
+++ b/articles/traveling-silk-road.html
@@ -202,6 +202,17 @@
             legacy of human connection across continents.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/traveling-through-taste-culinary-journey.html
+++ b/articles/traveling-through-taste-culinary-journey.html
@@ -205,6 +205,17 @@
             worldwide.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/traveling-through-time-oldest-cities.html
+++ b/articles/traveling-through-time-oldest-cities.html
@@ -205,6 +205,17 @@
             past.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/traveling-twist-unique-festivals-globe.html
+++ b/articles/traveling-twist-unique-festivals-globe.html
@@ -201,6 +201,17 @@
           fascinatingly unconventional.
         </p>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/traveling-without-trace.html
+++ b/articles/traveling-without-trace.html
@@ -205,6 +205,17 @@
             and respectful behavior.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/ultimate-family-solo-travel-planning-tips-2025.html
+++ b/articles/ultimate-family-solo-travel-planning-tips-2025.html
@@ -204,6 +204,17 @@
           cherish.
         </p>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <source

--- a/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html
+++ b/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">Get ready to unlock the secrets of unforgettable adventures with our Ultimate Travel Guide for 2025, packed with tips, top destinations, and insider experiences. From expert advice to exciting places, let’s dive into essential travel tips that will elevate your next journey.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1520285774798-2f1616131a68?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxsdXh1cnklMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnMlMjAyMDI1fGVufDB8MHx8fDE3NTE4ODI0NDN8MA&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/unexpected-journeys-realities-modern-travel-experiences.html
+++ b/articles/unexpected-journeys-realities-modern-travel-experiences.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">Modern travel often brings unexpected challenges and unique experiences that redefine our journeys. Navigating airport stories and travel realities sets the stage for uncovering hidden gems and essential tips for safer trips.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1552207311-2d6d6e8f1bd2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTE0OTM2NjB8MA&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html
+++ b/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">Escape the usual tourist trails and immerse yourself in unforgettable travel adventures that celebrate unique destinations. Let’s embark on a journey to discover exclusive experiences while ensuring your safety every step of the way.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1739918586913-249d35cd5af2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjByZW1vdGUlMjBkZXN0aW5hdGlvbnN8ZW58MHwwfHx8MTc1MTAxODY1Mnww&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/unforgettable-travel-adventures-inspiring-journeys-world.html
+++ b/articles/unforgettable-travel-adventures-inspiring-journeys-world.html
@@ -152,6 +152,17 @@
 </div>
   <p itemprop="description">Embark on a journey to explore unforgettable travel adventures and inspiring stories from around the world that ignite your wanderlust. From top destinations to empowering solo trips, this guide opens the door to experiences that will transform how you travel.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1634864221446-d7f305974814?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwbW91bnRhaW4lMjBsYW5kc2NhcGVzfGVufDB8MHx8fDE3NTM2MTc4Nzh8MA&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/unforgettable-travel-experiences-top-destinations-2025.html
+++ b/articles/unforgettable-travel-experiences-top-destinations-2025.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">Get ready to explore the most inspiring travel destinations of 2025 that promise unforgettable adventures and lasting memories. This guide will equip you with expert planning tips, essential safety advice, and creative ideas to make every trip extraordinary.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1510253687831-0f982d7862fc?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxicmVhdGh0YWtpbmclMjB0cmF2ZWwlMjBsYW5kc2NhcGVzJTIwMjAyNXxlbnwwfDB8fHwxNzUxNzUyODYwfDA&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/unforgettable-travel-journeys-unique-destinations-experiences.html
+++ b/articles/unforgettable-travel-journeys-unique-destinations-experiences.html
@@ -152,6 +152,17 @@
 </div>
   <p itemprop="description">Embark on unforgettable travel journeys that lead you to unique destinations and extraordinary experiences around the globe. From discovering hidden gems to planning your 2025 adventures, this guide begins with uncovering travel experiences that truly stand out.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1609464528647-bd84b5b6b461?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxleG90aWMlMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnN8ZW58MHwwfHx8MTc1NTI0NDcyMnww&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html
+++ b/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">Unforgettable travel stories ignite the passion for exploring new horizons, offering inspiration for your 2025 adventures. Dive into remarkable experiences and expert tips that set the stage for safe, culturally rich journeys ahead.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1608984075444-0e67cd80f696?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwdHJhdmVsJTIwbGFuZHNjYXBlc3xlbnwwfDB8fHwxNzUxODM5MjUyfDA&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/unplanned-journeys-travel-realities-insights.html
+++ b/articles/unplanned-journeys-travel-realities-insights.html
@@ -167,6 +167,17 @@
 </div>
   <p itemprop="description">Travel often leads us down unexpected paths, revealing the true nature of unplanned journeys and travel realities. This article dives into embracing surprise destinations and mastering the practical challenges that come with them.</p>
     
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+     crossorigin="anonymous"></script>
+<ins class="adsbygoogle"
+     style="display:block; text-align:center;"
+     data-ad-layout="in-article"
+     data-ad-format="fluid"
+     data-ad-client="ca-pub-1832988558915913"
+     data-ad-slot="9081784027"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
 <figure>
   <picture>
     <source media="(min-width:76rem)" srcset="https://images.unsplash.com/photo-1638745391040-15f6eb812215?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxjYW5kaWQlMjB0cmF2ZWxlcnMlMjBiYWNrcGFja2luZyUyMGNpdHklMjBzdHJlZXRzfGVufDB8MHx8fDE3NTE2NjY3NDB8MA&ixlib=rb-4.1.0&q=80&w=1080?w=1080 1080w" sizes="76rem" />

--- a/articles/unplugged-adventures-travel-without-technology.html
+++ b/articles/unplugged-adventures-travel-without-technology.html
@@ -197,6 +197,17 @@
           </p>
         </header>
 
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/unveiling-magic-polar-expeditions.html
+++ b/articles/unveiling-magic-polar-expeditions.html
@@ -206,6 +206,17 @@
             explorers and nature lovers alike.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/visit-earth-extremities.html
+++ b/articles/visit-earth-extremities.html
@@ -206,6 +206,17 @@
             makes each one extraordinary.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/voluntourism-impactful-travel.html
+++ b/articles/voluntourism-impactful-travel.html
@@ -202,6 +202,17 @@
             locals.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->

--- a/articles/voyage-through-vineyards-global-wine-regions.html
+++ b/articles/voyage-through-vineyards-global-wine-regions.html
@@ -206,6 +206,17 @@
             craftsmanship and inspire enthusiasts everywhere.
           </p>
         </header>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1832988558915913"
+             crossorigin="anonymous"></script>
+        <ins class="adsbygoogle"
+             style="display:block; text-align:center;"
+             data-ad-layout="in-article"
+             data-ad-format="fluid"
+             data-ad-client="ca-pub-1832988558915913"
+             data-ad-slot="9081784027"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
         <figure>
           <picture>
             <!-- Desktop: full‑width -->


### PR DESCRIPTION
## Summary
- embed AdSense ad block between article headers and main figures across all articles

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f4448fe8c8329b3ec66700b5cc624