### PR TITLE
Add author profile pages with article links

### DIFF
--- a/authors/danielle-eyebright.html
+++ b/authors/danielle-eyebright.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="google-adsense-account" content="ca-pub-1832988558915913" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Danielle is an online writer and editor who is committed to providing valuable information to her readers. When he's not writing, he enjoys gaming and spending time with her family and beloved German Shepherd." />
+    <meta name="author" content="Danielle Eyebright" />
+    <link rel="stylesheet" href="../assets/styles/style.css" />
+    <title>Travel Guide | Danielle Eyebright</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Danielle Eyebright",
+      "description": "Danielle is an online writer and editor who is committed to providing valuable information to her readers. When he's not writing, he enjoys gaming and spending time with her family and beloved German Shepherd.",
+      "url": "https://exitfloridakeys.com/authors/danielle-eyebright.html"
+    }
+    </script>
+  </head>
+  <body>
+    <header>
+      <a rel="home" href="/" id="title">🏠 Travel Guide</a>
+      <hr />
+    </header>
+    <main>
+      <h1>Danielle Eyebright</h1>
+      <p>Danielle is an online writer and editor who is committed to providing valuable information to her readers. When he's not writing, he enjoys gaming and spending time with her family and beloved German Shepherd.</p>
+      <h2>Articles</h2>
+      <ul>
+        <li><a href="/articles/discovering-underwater-world-best-snorkeling-spots-globally.html">Travel Guide | Discovering the Underwater World Best Snorkeling Spots Globally</a></li>
+        <li><a href="/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html">Audio Travel Guide | Navigating Modern Travel: Safety, Culture, and Unique Destinations in 2025</a></li>
+        <li><a href="/articles/navigating-complexities-of-travel-tips-tales-realities.html">Travel Guide | Navigating the Complexities of Travel: Tales, Tips, and Realities</a></li>
+        <li><a href="/articles/chasing-northern-lights-best-places.html">Travel Guide | Chasing Northern Lights: Best Places to Witness this Natural Phenomenon</a></li>
+        <li><a href="/articles/traveling-silk-road.html">Travel Guide | Traveling the Silk Road: A Journey Through History</a></li>
+        <li><a href="/articles/exploring-emerging-travel-trends-and-unique-hobby-inspirations.html">Travel Guide | Exploring Emerging Travel Trends and Unique Hobby Inspirations</a></li>
+        <li><a href="/articles/explore-unique-travel-experiences-hidden-gems-2025.html">Audio Travel Guide | Explore Unique Travel Experiences and Hidden Gems in 2025</a></li>
+        <li><a href="/articles/traveling-through-time-oldest-cities.html">Travel Guide | Traveling Through Time: Visiting the Oldest Cities in the World</a></li>
+        <li><a href="/articles/solo-travel-guide-southeast-asia-safety.html">Travel Guide | Solo Traveler's Guide to Southeast Asia How to Travel Confidently and Safely</a></li>
+        <li><a href="/articles/culinary-trails-origins-iconic-street-food.html">Travel Guide | Culinary Trails: Tracing the Origins of Iconic Street Food</a></li>
+      </ul>
+      <p><a href="/about-us.html">Back to About Us</a></p>
+    </main>
+    <footer>
+      <nav aria-label="Footer navigation">
+        <ul class="footer-links">
+          <li>
+            <a rel="nofollow" href="/privacy-policy.html">Privacy Policy</a>
+          </li>
+          <li><a rel="nofollow" href="/contact.html">Contact</a></li>
+          <li><a rel="nofollow" href="/about-us.html">About Us</a></li>
+          <li><a rel="nofollow" href="/imprint.html">Imprint</a></li>
+        </ul>
+      </nav>
+      <p>&copy; 2025 Travel Guide. All rights reserved.</p>
+    </footer>
+  </body>
+</html>

--- a/authors/daniil-kharms.html
+++ b/authors/daniil-kharms.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="google-adsense-account" content="ca-pub-1832988558915913" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Daniil is a passionate traveler and writer who loves to explore new cultures and cuisines. She enjoys sharing her travel stories and tips with others, hoping to inspire them to embark on their own adventures." />
+    <meta name="author" content="Daniil Kharms" />
+    <link rel="stylesheet" href="../assets/styles/style.css" />
+    <title>Travel Guide | Daniil Kharms</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Daniil Kharms",
+      "description": "Daniil is a passionate traveler and writer who loves to explore new cultures and cuisines. She enjoys sharing her travel stories and tips with others, hoping to inspire them to embark on their own adventures.",
+      "url": "https://exitfloridakeys.com/authors/daniil-kharms.html"
+    }
+    </script>
+  </head>
+  <body>
+    <header>
+      <a rel="home" href="/" id="title">🏠 Travel Guide</a>
+      <hr />
+    </header>
+    <main>
+      <h1>Daniil Kharms</h1>
+      <p>Daniil is a passionate traveler and writer who loves to explore new cultures and cuisines. She enjoys sharing her travel stories and tips with others, hoping to inspire them to embark on their own adventures.</p>
+      <h2>Articles</h2>
+      <ul>
+        <li><a href="/articles/best-safari-destinations.html">Travel Guide | Experiencing Wildlife: Best Safari Destinations Around the Globe</a></li>
+        <li><a href="/articles/navigating-modern-travel-safety-tips-destinations-experiences.html">Audio Travel Guide | Navigating Modern Travel: Safety Tips, Destinations, and Experiences</a></li>
+        <li><a href="/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html">Audio Travel Guide | Navigating Global Travel: Unique Destinations, Challenges, and Cultural Insights</a></li>
+        <li><a href="/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html">Audio Travel Guide | Mastering Travel Flexibility: Tips and Inspiring Stories for Adventurous Journeys</a></li>
+        <li><a href="/articles/unexpected-journeys-realities-modern-travel-experiences.html">Audio Travel Guide | Unexpected Journeys and Realities: Exploring Modern Travel Experiences</a></li>
+        <li><a href="/articles/unforgettable-travel-experiences-top-destinations-2025.html">Audio Travel Guide | Unforgettable Travel Experiences and Top Destinations in 2025</a></li>
+        <li><a href="/articles/going-green-vegan-vegetarian-travel.html">Travel Guide | Going Green: The Rise of Vegan and Vegetarian Travel</a></li>
+        <li><a href="/articles/unveiling-magic-polar-expeditions.html">Travel Guide | Unveiling the Magic of Polar Expeditions: Discovering Antarctica and the North Pole</a></li>
+        <li><a href="/articles/cultural-immersion-experiences.html">Travel Guide | Cultural Immersion Experiences That Transcend the Tourist Traps</a></li>
+        <li><a href="/articles/exploring-emerging-travel-trends-unique-hobby-inspirations.html">Travel Guide | Exploring Emerging Travel Trends and Unique Hobby Inspirations</a></li>
+        <li><a href="/articles/architectural-marvels-modern-wonders-world.html">Travel Guide | Architectural Marvels: A Closer Look at Modern Wonders of the World</a></li>
+        <li><a href="/articles/navigating-night-markets-food-lovers-guide.html">Travel Guide | Navigating Night Markets: A Food Lover's Guide Around the World</a></li>
+      </ul>
+      <p><a href="/about-us.html">Back to About Us</a></p>
+    </main>
+    <footer>
+      <nav aria-label="Footer navigation">
+        <ul class="footer-links">
+          <li>
+            <a rel="nofollow" href="/privacy-policy.html">Privacy Policy</a>
+          </li>
+          <li><a rel="nofollow" href="/contact.html">Contact</a></li>
+          <li><a rel="nofollow" href="/about-us.html">About Us</a></li>
+          <li><a rel="nofollow" href="/imprint.html">Imprint</a></li>
+        </ul>
+      </nav>
+      <p>&copy; 2025 Travel Guide. All rights reserved.</p>
+    </footer>
+  </body>
+</html>

--- a/authors/david-agnew.html
+++ b/authors/david-agnew.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="google-adsense-account" content="ca-pub-1832988558915913" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="David is a health and wellness writer with a background in journalism. He’s spent years researching the science behind mindful travel and adventure therapy, helping readers find balance and meaning on the road." />
+    <meta name="author" content="David Agnew" />
+    <link rel="stylesheet" href="../assets/styles/style.css" />
+    <title>Travel Guide | David Agnew</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "David Agnew",
+      "description": "David is a health and wellness writer with a background in journalism. He’s spent years researching the science behind mindful travel and adventure therapy, helping readers find balance and meaning on the road.",
+      "url": "https://exitfloridakeys.com/authors/david-agnew.html"
+    }
+    </script>
+  </head>
+  <body>
+    <header>
+      <a rel="home" href="/" id="title">🏠 Travel Guide</a>
+      <hr />
+    </header>
+    <main>
+      <h1>David Agnew</h1>
+      <p>David is a health and wellness writer with a background in journalism. He’s spent years researching the science behind mindful travel and adventure therapy, helping readers find balance and meaning on the road.</p>
+      <h2>Articles</h2>
+      <ul>
+        <li><a href="/articles/touring-tropics-comprehensive-guide.html">Travel Guide | Touring the Tropics: A Comprehensive Guide to Tropical Destinations</a></li>
+        <li><a href="/articles/navigating-realities-wonders-modern-travel-2025.html">Audio Travel Guide | Navigating Realities and Wonders of Modern Travel in 2025</a></li>
+        <li><a href="/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html">Audio Travel Guide | Ultimate Travel Guide: Tips, Destinations, and Insider Experiences for 2025</a></li>
+        <li><a href="/articles/exploring-untouched-forests.html">Travel Guide | Into the Wild: Exploring the Untouched Forests of the World</a></li>
+        <li><a href="/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html">Audio Travel Guide | Unforgettable Travel Stories and Expert Tips for 2025 Adventures</a></li>
+        <li><a href="/articles/unplugged-adventures-travel-without-technology.html">Travel Guide | Unplugged Adventures Experiencing Travel Without Technology</a></li>
+        <li><a href="/articles/exploring-unique-destinations-travel-experiences-2025.html">Audio Travel Guide | Exploring Unique Destinations and Travel Experiences Worldwide in 2025</a></li>
+        <li><a href="/articles/traveling-without-trace.html">Travel Guide | Traveling Without a Trace: A Guide to Leave No Trace Principles</a></li>
+        <li><a href="/articles/navigating-modern-travel-insights-experiences-tips-2025.html">Travel Guide | Navigating Modern Travel: Insights, Experiences, and Tips for 2025</a></li>
+        <li><a href="/articles/transcontinental-trails-world.html">Travel Guide | Transcontinental Trails: Experiencing the Great Hiking Trails Around the World</a></li>
+      </ul>
+      <p><a href="/about-us.html">Back to About Us</a></p>
+    </main>
+    <footer>
+      <nav aria-label="Footer navigation">
+        <ul class="footer-links">
+          <li>
+            <a rel="nofollow" href="/privacy-policy.html">Privacy Policy</a>
+          </li>
+          <li><a rel="nofollow" href="/contact.html">Contact</a></li>
+          <li><a rel="nofollow" href="/about-us.html">About Us</a></li>
+          <li><a rel="nofollow" href="/imprint.html">Imprint</a></li>
+        </ul>
+      </nav>
+      <p>&copy; 2025 Travel Guide. All rights reserved.</p>
+    </footer>
+  </body>
+</html>

--- a/authors/davina-blake.html
+++ b/authors/davina-blake.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="google-adsense-account" content="ca-pub-1832988558915913" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Davina covers the intersection of finance and travel, breaking down how to fund your adventures smartly. When she’s not crunching numbers, you’ll find her exploring off‑grid homestays with her camera in hand." />
+    <meta name="author" content="Davina Blake" />
+    <link rel="stylesheet" href="../assets/styles/style.css" />
+    <title>Travel Guide | Davina Blake</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Davina Blake",
+      "description": "Davina covers the intersection of finance and travel, breaking down how to fund your adventures smartly. When she’s not crunching numbers, you’ll find her exploring off‑grid homestays with her camera in hand.",
+      "url": "https://exitfloridakeys.com/authors/davina-blake.html"
+    }
+    </script>
+  </head>
+  <body>
+    <header>
+      <a rel="home" href="/" id="title">🏠 Travel Guide</a>
+      <hr />
+    </header>
+    <main>
+      <h1>Davina Blake</h1>
+      <p>Davina covers the intersection of finance and travel, breaking down how to fund your adventures smartly. When she’s not crunching numbers, you’ll find her exploring off‑grid homestays with her camera in hand.</p>
+      <h2>Articles</h2>
+      <ul>
+        <li><a href="/articles/hidden-gems-uncharted-travel-destinations.html">Travel Guide | Hidden Gems Uncharted Travel Destinations Around the World</a></li>
+        <li><a href="/articles/top-10-hidden-gems-europe.html">Travel Guide | Top 10 Hidden Gems to Explore in Europe</a></li>
+        <li><a href="/articles/visit-earth-extremities.html">Travel Guide | A Visit to Earth’s Extremities: A Guide to Extreme Geographical Points</a></li>
+        <li><a href="/articles/embracing-eco-tourism-sustainable-journey-costa-rica.html">Travel Guide | Embracing Eco-Tourism A Sustainable Journey through Costa Rica</a></li>
+        <li><a href="/articles/dark-tourism-worlds-haunting-locations.html">Travel Guide | Dark Tourism Visiting The World's Most Haunting Locations</a></li>
+        <li><a href="/articles/roaming-roof-world-himalayas-guide.html">Travel Guide | Roaming the Roof of the World: A Guide to the Himalayas</a></li>
+        <li><a href="/articles/pedal-paradises-destinations-cycling-enthusiasts.html">Travel Guide | Pedal Through Paradises: Best Destinations for Cycling Enthusiasts</a></li>
+      </ul>
+      <p><a href="/about-us.html">Back to About Us</a></p>
+    </main>
+    <footer>
+      <nav aria-label="Footer navigation">
+        <ul class="footer-links">
+          <li>
+            <a rel="nofollow" href="/privacy-policy.html">Privacy Policy</a>
+          </li>
+          <li><a rel="nofollow" href="/contact.html">Contact</a></li>
+          <li><a rel="nofollow" href="/about-us.html">About Us</a></li>
+          <li><a rel="nofollow" href="/imprint.html">Imprint</a></li>
+        </ul>
+      </nav>
+      <p>&copy; 2025 Travel Guide. All rights reserved.</p>
+    </footer>
+  </body>
+</html>

--- a/authors/frank-axton.html
+++ b/authors/frank-axton.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="google-adsense-account" content="ca-pub-1832988558915913" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Frank writes about sustainable and immersive travel experiences. A former environmental engineer, he now hikes, kayaks, and documents eco‑friendly projects that give back to local communities." />
+    <meta name="author" content="Frank Axton" />
+    <link rel="stylesheet" href="../assets/styles/style.css" />
+    <title>Travel Guide | Frank Axton</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Frank Axton",
+      "description": "Frank writes about sustainable and immersive travel experiences. A former environmental engineer, he now hikes, kayaks, and documents eco‑friendly projects that give back to local communities.",
+      "url": "https://exitfloridakeys.com/authors/frank-axton.html"
+    }
+    </script>
+  </head>
+  <body>
+    <header>
+      <a rel="home" href="/" id="title">🏠 Travel Guide</a>
+      <hr />
+    </header>
+    <main>
+      <h1>Frank Axton</h1>
+      <p>Frank writes about sustainable and immersive travel experiences. A former environmental engineer, he now hikes, kayaks, and documents eco‑friendly projects that give back to local communities.</p>
+      <h2>Articles</h2>
+      <ul>
+        <li><a href="/articles/exploring-unesco-sites.html">Travel Guide | Exploring UNESCO World Heritage Sites: A Journey into History and Culture</a></li>
+        <li><a href="/articles/exploring-worlds-historical-walking-routes.html">Travel Guide | A Walk Through Time: Exploring World's Historical Walking Routes</a></li>
+        <li><a href="/articles/global-gastronomy-tasting-traditional-dishes-different-cultures.html">Travel Guide | Global Gastronomy: Tasting Traditional Dishes Across Different Cultures</a></li>
+        <li><a href="/articles/voluntourism-impactful-travel.html">Travel Guide | Voluntourism: Impactful Travel with a Cause</a></li>
+        <li><a href="/articles/best-travel-apps.html">Travel Guide | Best Travel Apps to Make Your Journey Easier</a></li>
+        <li><a href="/articles/exploring-arctic-travel-guide.html">Travel Guide | Exploring the Arctic: A Travel Guide to Life in the Far North</a></li>
+        <li><a href="/articles/voyage-through-vineyards-global-wine-regions.html">Travel Guide | A Voyage Through the Vineyards: Exploring Wine Regions Around the Globe</a></li>
+        <li><a href="/articles/exploring-trending-travel-destinations-and-relaxing-hobby-ideas.html">Travel Guide | Exploring Trending Travel Destinations and Relaxing Hobby Ideas</a></li>
+        <li><a href="/articles/african-safari-experience-a-journey-into-the-wild.html">Travel Guide | The African Safari Experience: A Journey into the Wild</a></li>
+        <li><a href="/articles/ultimate-family-solo-travel-planning-tips-2025.html">Travel Guide | Ultimate Family and Solo Travel Planning: Tips and Destinations for 2025</a></li>
+        <li><a href="/articles/top-surfing-destinations-world.html">Travel Guide | Riding the Waves: Top Surfing Destinations Around the World</a></li>
+        <li><a href="/articles/inspiring-travel-destinations-tips-2025-adventures.html">Audio Travel Guide | Top Inspiring Travel Destinations and Tips for 2025 Adventures</a></li>
+        <li><a href="/articles/traveling-through-taste-culinary-journey.html">Travel Guide | Traveling Through Taste: A Culinary Journey Around the Globe</a></li>
+        <li><a href="/articles/digital-nomad-life-world.html">Travel Guide | Digital Nomad Life: Exploring the World while Working Remotely</a></li>
+      </ul>
+      <p><a href="/about-us.html">Back to About Us</a></p>
+    </main>
+    <footer>
+      <nav aria-label="Footer navigation">
+        <ul class="footer-links">
+          <li>
+            <a rel="nofollow" href="/privacy-policy.html">Privacy Policy</a>
+          </li>
+          <li><a rel="nofollow" href="/contact.html">Contact</a></li>
+          <li><a rel="nofollow" href="/about-us.html">About Us</a></li>
+          <li><a rel="nofollow" href="/imprint.html">Imprint</a></li>
+        </ul>
+      </nav>
+      <p>&copy; 2025 Travel Guide. All rights reserved.</p>
+    </footer>
+  </body>
+</html>

--- a/authors/lisa-crow.html
+++ b/authors/lisa-crow.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="google-adsense-account" content="ca-pub-1832988558915913" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Lisa is a health journalist turned travel writer. She specializes in wellness retreats around the globe, from Himalayan yoga ashrams to Mediterranean spa towns." />
+    <meta name="author" content="Lisa Crow" />
+    <link rel="stylesheet" href="../assets/styles/style.css" />
+    <title>Travel Guide | Lisa Crow</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Lisa Crow",
+      "description": "Lisa is a health journalist turned travel writer. She specializes in wellness retreats around the globe, from Himalayan yoga ashrams to Mediterranean spa towns.",
+      "url": "https://exitfloridakeys.com/authors/lisa-crow.html"
+    }
+    </script>
+  </head>
+  <body>
+    <header>
+      <a rel="home" href="/" id="title">🏠 Travel Guide</a>
+      <hr />
+    </header>
+    <main>
+      <h1>Lisa Crow</h1>
+      <p>Lisa is a health journalist turned travel writer. She specializes in wellness retreats around the globe, from Himalayan yoga ashrams to Mediterranean spa towns.</p>
+      <h2>Articles</h2>
+      <ul>
+        <li><a href="/articles/glamping-world-luxury-tents-incredible-views.html">Travel Guide | Glamping Around the World: Luxury Tents and Incredible Views</a></li>
+        <li><a href="/articles/historic-railways-world-journey.html">Travel Guide | Historic Railways of the World: A Journey Through Time and Cultures</a></li>
+        <li><a href="/articles/beyond-hostels-hotels-unique-accommodations-adventurous-traveler.html">Travel Guide | Beyond Hostels and Hotels: Unique Accommodations for the Adventurous Traveler</a></li>
+        <li><a href="/articles/unforgettable-travel-journeys-unique-destinations-experiences.html">Audio Travel Guide | Unforgettable Travel Journeys: Exploring Unique Destinations and Experiences</a></li>
+        <li><a href="/articles/sustainable-food-explorations.html">Travel Guide | Sustainable Food Explorations: A Foodie's Guide to Eco-friendly Dining Worldwide</a></li>
+        <li><a href="/articles/timeless-timelines-history-iconic-landmarks.html">Travel Guide | Timeless Timelines: Unraveling the History of Iconic Landmarks</a></li>
+        <li><a href="/articles/eco-friendly-traveling-world-sustainably.html">Travel Guide | Eco-Friendly Traveling How to See the World Sustainably</a></li>
+        <li><a href="/articles/behind-scenes-worlds-largest-festivals.html">Travel Guide | Behind the Scenes: How the World's Largest Festivals are Organized</a></li>
+        <li><a href="/articles/river-cruises-europe.html">Travel Guide | River Cruises: A Unique Way to Discover Hidden Gems of Europe</a></li>
+        <li><a href="/articles/exploring-worlds-most-religious-sites.html">Travel Guide | The Sacred Journey: Exploring the World's Most Religious Sites</a></li>
+        <li><a href="/articles/travel-budget-tips.html">Travel Guide | How to Travel on a Budget Without Missing Out</a></li>
+      </ul>
+      <p><a href="/about-us.html">Back to About Us</a></p>
+    </main>
+    <footer>
+      <nav aria-label="Footer navigation">
+        <ul class="footer-links">
+          <li>
+            <a rel="nofollow" href="/privacy-policy.html">Privacy Policy</a>
+          </li>
+          <li><a rel="nofollow" href="/contact.html">Contact</a></li>
+          <li><a rel="nofollow" href="/about-us.html">About Us</a></li>
+          <li><a rel="nofollow" href="/imprint.html">Imprint</a></li>
+        </ul>
+      </nav>
+      <p>&copy; 2025 Travel Guide. All rights reserved.</p>
+    </footer>
+  </body>
+</html>

--- a/authors/shamina-cody.html
+++ b/authors/shamina-cody.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="google-adsense-account" content="ca-pub-1832988558915913" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Shamina explores the cultural side of travel—festivals, street food and local arts. A lifelong entertainer, she weaves personal anecdotes into every guide she writes." />
+    <meta name="author" content="Shamina Cody" />
+    <link rel="stylesheet" href="../assets/styles/style.css" />
+    <title>Travel Guide | Shamina Cody</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Shamina Cody",
+      "description": "Shamina explores the cultural side of travel—festivals, street food and local arts. A lifelong entertainer, she weaves personal anecdotes into every guide she writes.",
+      "url": "https://exitfloridakeys.com/authors/shamina-cody.html"
+    }
+    </script>
+  </head>
+  <body>
+    <header>
+      <a rel="home" href="/" id="title">🏠 Travel Guide</a>
+      <hr />
+    </header>
+    <main>
+      <h1>Shamina Cody</h1>
+      <p>Shamina explores the cultural side of travel—festivals, street food and local arts. A lifelong entertainer, she weaves personal anecdotes into every guide she writes.</p>
+      <h2>Articles</h2>
+      <ul>
+        <li><a href="/articles/unforgettable-travel-adventures-inspiring-journeys-world.html">Audio Travel Guide | Unforgettable Travel Adventures and Inspiring Journeys Around the World</a></li>
+        <li><a href="/articles/explore-enchanting-destinations-smart-travel-planning-2025.html">Audio Travel Guide | Explore Enchanting Destinations and Smart Travel Planning Tips for 2025</a></li>
+        <li><a href="/articles/navigating-solo-journeys-travel-challenges-2025.html">Audio Travel Guide | Navigating Solo Journeys and Travel Challenges in 2025</a></li>
+        <li><a href="/articles/discover-transformative-travel-stories-trending-destinations.html">Audio Travel Guide | Discover Transformative Travel Stories and Top Trending Destinations</a></li>
+        <li><a href="/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html">Audio Travel Guide | Navigating Travel Experiences: Tips, Challenges, and Inspiring Journeys</a></li>
+        <li><a href="/articles/exploring-new-horizons-top-travel-tips-destinations-2025.html">Audio Travel Guide | Exploring New Horizons: Top Travel Tips and Destinations for 2025</a></li>
+        <li><a href="/articles/exploring-authentic-travel-experiences-hidden-gems-challenges.html">Travel Guide | Exploring Authentic Travel Experiences: From Hidden Gems to Real Challenges</a></li>
+        <li><a href="/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html">Audio Travel Guide | Unforgettable Travel Adventures: Exploring Unique Destinations Safely</a></li>
+        <li><a href="/articles/solo-travel-safety-guide.html">Travel Guide | The Ultimate Guide to Solo Travel Safety</a></li>
+        <li><a href="/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html">Audio Travel Guide | Navigating Modern Travel: Experiences, Challenges, and Emerging Destinations</a></li>
+        <li><a href="/articles/sanctuaries-sky-worlds-picturesque-mountain-retreats.html">Travel Guide | Sanctuaries in the Sky: World's Most Picturesque Mountain Retreats</a></li>
+      </ul>
+      <p><a href="/about-us.html">Back to About Us</a></p>
+    </main>
+    <footer>
+      <nav aria-label="Footer navigation">
+        <ul class="footer-links">
+          <li>
+            <a rel="nofollow" href="/privacy-policy.html">Privacy Policy</a>
+          </li>
+          <li><a rel="nofollow" href="/contact.html">Contact</a></li>
+          <li><a rel="nofollow" href="/about-us.html">About Us</a></li>
+          <li><a rel="nofollow" href="/imprint.html">Imprint</a></li>
+        </ul>
+      </nav>
+      <p>&copy; 2025 Travel Guide. All rights reserved.</p>
+    </footer>
+  </body>
+</html>

--- a/authors/susanna-lem.html
+++ b/authors/susanna-lem.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="google-adsense-account" content="ca-pub-1832988558915913" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Susanna writes both finance and travel pieces. She’s best known for her deep dives into budget‑friendly itineraries and creative ways to see the world without breaking the bank." />
+    <meta name="author" content="Susanna Lem" />
+    <link rel="stylesheet" href="../assets/styles/style.css" />
+    <title>Travel Guide | Susanna Lem</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Susanna Lem",
+      "description": "Susanna writes both finance and travel pieces. She’s best known for her deep dives into budget‑friendly itineraries and creative ways to see the world without breaking the bank.",
+      "url": "https://exitfloridakeys.com/authors/susanna-lem.html"
+    }
+    </script>
+  </head>
+  <body>
+    <header>
+      <a rel="home" href="/" id="title">🏠 Travel Guide</a>
+      <hr />
+    </header>
+    <main>
+      <h1>Susanna Lem</h1>
+      <p>Susanna writes both finance and travel pieces. She’s best known for her deep dives into budget‑friendly itineraries and creative ways to see the world without breaking the bank.</p>
+      <h2>Articles</h2>
+      <ul>
+        <li><a href="/articles/exploring-scottish-highlands.html">Travel Guide | Exploring the Highlands: A Guide to the Scottish Highlands</a></li>
+        <li><a href="/articles/unplanned-journeys-travel-realities-insights.html">Audio Travel Guide | Unplanned Journeys and Travel Realities: Insights for Savvy Adventurers</a></li>
+        <li><a href="/articles/traveling-twist-unique-festivals-globe.html">Travel Guide | Traveling with a Twist – Unique Festivals Around the Globe</a></li>
+        <li><a href="/articles/travel-hacks-tips-save-money-time.html">Travel Guide | Travel Hacks Essential Tips to Save Money and Time While Traveling</a></li>
+      </ul>
+      <p><a href="/about-us.html">Back to About Us</a></p>
+    </main>
+    <footer>
+      <nav aria-label="Footer navigation">
+        <ul class="footer-links">
+          <li>
+            <a rel="nofollow" href="/privacy-policy.html">Privacy Policy</a>
+          </li>
+          <li><a rel="nofollow" href="/contact.html">Contact</a></li>
+          <li><a rel="nofollow" href="/about-us.html">About Us</a></li>
+          <li><a rel="nofollow" href="/imprint.html">Imprint</a></li>
+        </ul>
+      </nav>
+      <p>&copy; 2025 Travel Guide. All rights reserved.</p>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `authors/` directory with individual author profile pages
- include bios, structured metadata, and lists of related articles
- link back to About Us page from each profile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af2abbd2bc83298d015b3236497f0b