### PR TITLE
Link author names to author profile pages

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -110,7 +110,7 @@
                 title="Designed by Freepik - Danielle Eyebright"
                 class="team-avatar"
             /></a>
-            <h3>Danielle Eyebright</h3>
+            <h3><a href="/authors/danielle-eyebright.html">Danielle Eyebright</a></h3>
             <div><em>Contributor</em></div>
             <p>
               Danielle is an online writer and editor who is committed to
@@ -134,7 +134,7 @@
                 title="Designed by Freepik - Daniil Kharms"
                 class="team-avatar"
             /></a>
-            <h3>Daniil Kharms</h3>
+            <h3><a href="/authors/daniil-kharms.html">Daniil Kharms</a></h3>
             <div><em>Contributor</em></div>
             <p>
               Daniil is a passionate traveler and writer who loves to explore
@@ -158,7 +158,7 @@
                 title="Designed by Freepik - David Agnew"
                 class="team-avatar"
             /></a>
-            <h3>David Agnew</h3>
+            <h3><a href="/authors/david-agnew.html">David Agnew</a></h3>
             <div><em>Contributor</em></div>
             <p>
               David is a health and wellness writer with a background in
@@ -182,7 +182,7 @@
                 title="Designed by Freepik - Davina Blake"
                 class="team-avatar"
             /></a>
-            <h3>Davina Blake</h3>
+            <h3><a href="/authors/davina-blake.html">Davina Blake</a></h3>
             <div><em>Contributor</em></div>
             <p>
               Davina covers the intersection of finance and travel, breaking
@@ -206,7 +206,7 @@
                 title="Designed by Freepik - Frank Axton"
                 class="team-avatar"
             /></a>
-            <h3>Frank Axton</h3>
+            <h3><a href="/authors/frank-axton.html">Frank Axton</a></h3>
             <div><em>Contributor</em></div>
             <p>
               Frank writes about sustainable and immersive travel experiences. A
@@ -228,7 +228,7 @@
                 title="Designed by Freepik - Lisa Crow"
                 class="team-avatar"
             /></a>
-            <h3>Lisa Crow</h3>
+            <h3><a href="/authors/lisa-crow.html">Lisa Crow</a></h3>
             <div><em>Contributor</em></div>
             <p>
               Lisa is a health journalist turned travel writer. She specializes
@@ -250,7 +250,7 @@
                 title="Designed by Freepik - Shamina Cody"
                 class="team-avatar"
             /></a>
-            <h3>Shamina Cody</h3>
+            <h3><a href="/authors/shamina-cody.html">Shamina Cody</a></h3>
             <div><em>Contributor</em></div>
             <p>
               Shamina explores the cultural side of travel—festivals, street
@@ -272,7 +272,7 @@
                 title="Designed by Freepik - Susanna Lem"
                 class="team-avatar"
             /></a>
-            <h3>Susanna Lem</h3>
+            <h3><a href="/authors/susanna-lem.html">Susanna Lem</a></h3>
             <div><em>Contributor</em></div>
             <p>
               Susanna writes both finance and travel pieces. She’s best known


### PR DESCRIPTION
## Summary
- Wrap each team member's name on About Us page with a link to the corresponding author profile

## Testing
- `npx -y html-validate about-us.html` *(fails: Expected omitted end tag <meta> instead of self-closing element <meta/>, etc.)*
- `npx -y pa11y about-us.html` *(fails: error while loading shared libraries: libXcomposite.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b02c93ec008329b5363672ed2d95c8