### PR TITLE
Remove prefixes from author article links

### DIFF
--- a/authors/danielle-eyebright.html
+++ b/authors/danielle-eyebright.html
@@ -28,16 +28,16 @@
       <p>Danielle is an online writer and editor who is committed to providing valuable information to her readers. When he's not writing, he enjoys gaming and spending time with her family and beloved German Shepherd.</p>
       <h2>Articles by Danielle Eyebright</h2>
       <ul>
-        <li><a href="/articles/explore-unique-travel-experiences-hidden-gems-2025.html" rel="author">Audio Travel Guide | Explore Unique Travel Experiences and Hidden Gems in 2025</a></li>
-        <li><a href="/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html" rel="author">Audio Travel Guide | Navigating Modern Travel: Safety, Culture, and Unique Destinations in 2025</a></li>
-        <li><a href="/articles/chasing-northern-lights-best-places.html" rel="author">Travel Guide | Chasing Northern Lights: Best Places to Witness this Natural Phenomenon</a></li>
-        <li><a href="/articles/culinary-trails-origins-iconic-street-food.html" rel="author">Travel Guide | Culinary Trails: Tracing the Origins of Iconic Street Food</a></li>
-        <li><a href="/articles/discovering-underwater-world-best-snorkeling-spots-globally.html" rel="author">Travel Guide | Discovering the Underwater World Best Snorkeling Spots Globally</a></li>
-        <li><a href="/articles/exploring-emerging-travel-trends-and-unique-hobby-inspirations.html" rel="author">Travel Guide | Exploring Emerging Travel Trends and Unique Hobby Inspirations</a></li>
-        <li><a href="/articles/navigating-complexities-of-travel-tips-tales-realities.html" rel="author">Travel Guide | Navigating the Complexities of Travel: Tales, Tips, and Realities</a></li>
-        <li><a href="/articles/solo-travel-guide-southeast-asia-safety.html" rel="author">Travel Guide | Solo Traveler's Guide to Southeast Asia How to Travel Confidently and Safely</a></li>
-        <li><a href="/articles/traveling-silk-road.html" rel="author">Travel Guide | Traveling the Silk Road: A Journey Through History</a></li>
-        <li><a href="/articles/traveling-through-time-oldest-cities.html" rel="author">Travel Guide | Traveling Through Time: Visiting the Oldest Cities in the World</a></li>
+        <li><a href="/articles/explore-unique-travel-experiences-hidden-gems-2025.html" rel="author">Explore Unique Travel Experiences and Hidden Gems in 2025</a></li>
+        <li><a href="/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html" rel="author">Navigating Modern Travel: Safety, Culture, and Unique Destinations in 2025</a></li>
+        <li><a href="/articles/chasing-northern-lights-best-places.html" rel="author">Chasing Northern Lights: Best Places to Witness this Natural Phenomenon</a></li>
+        <li><a href="/articles/culinary-trails-origins-iconic-street-food.html" rel="author">Culinary Trails: Tracing the Origins of Iconic Street Food</a></li>
+        <li><a href="/articles/discovering-underwater-world-best-snorkeling-spots-globally.html" rel="author">Discovering the Underwater World Best Snorkeling Spots Globally</a></li>
+        <li><a href="/articles/exploring-emerging-travel-trends-and-unique-hobby-inspirations.html" rel="author">Exploring Emerging Travel Trends and Unique Hobby Inspirations</a></li>
+        <li><a href="/articles/navigating-complexities-of-travel-tips-tales-realities.html" rel="author">Navigating the Complexities of Travel: Tales, Tips, and Realities</a></li>
+        <li><a href="/articles/solo-travel-guide-southeast-asia-safety.html" rel="author">Solo Traveler's Guide to Southeast Asia How to Travel Confidently and Safely</a></li>
+        <li><a href="/articles/traveling-silk-road.html" rel="author">Traveling the Silk Road: A Journey Through History</a></li>
+        <li><a href="/articles/traveling-through-time-oldest-cities.html" rel="author">Traveling Through Time: Visiting the Oldest Cities in the World</a></li>
       </ul>
       <p><a rel="nofollow" href="/about-us.html">Back to About Us</a></p>
     </main>

--- a/authors/daniil-kharms.html
+++ b/authors/daniil-kharms.html
@@ -28,18 +28,18 @@
       <p>Daniil is a passionate traveler and writer who loves to explore new cultures and cuisines. She enjoys sharing her travel stories and tips with others, hoping to inspire them to embark on their own adventures.</p>
       <h2>Articles by Daniil Kharms</h2>
       <ul>
-        <li><a href="/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html" rel="author">Audio Travel Guide | Mastering Travel Flexibility: Tips and Inspiring Stories for Adventurous Journeys</a></li>
-        <li><a href="/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html" rel="author">Audio Travel Guide | Navigating Global Travel: Unique Destinations, Challenges, and Cultural Insights</a></li>
-        <li><a href="/articles/navigating-modern-travel-safety-tips-destinations-experiences.html" rel="author">Audio Travel Guide | Navigating Modern Travel: Safety Tips, Destinations, and Experiences</a></li>
-        <li><a href="/articles/unexpected-journeys-realities-modern-travel-experiences.html" rel="author">Audio Travel Guide | Unexpected Journeys and Realities: Exploring Modern Travel Experiences</a></li>
-        <li><a href="/articles/unforgettable-travel-experiences-top-destinations-2025.html" rel="author">Audio Travel Guide | Unforgettable Travel Experiences and Top Destinations in 2025</a></li>
-        <li><a href="/articles/architectural-marvels-modern-wonders-world.html" rel="author">Travel Guide | Architectural Marvels: A Closer Look at Modern Wonders of the World</a></li>
-        <li><a href="/articles/cultural-immersion-experiences.html" rel="author">Travel Guide | Cultural Immersion Experiences That Transcend the Tourist Traps</a></li>
-        <li><a href="/articles/best-safari-destinations.html" rel="author">Travel Guide | Experiencing Wildlife: Best Safari Destinations Around the Globe</a></li>
-        <li><a href="/articles/exploring-emerging-travel-trends-unique-hobby-inspirations.html" rel="author">Travel Guide | Exploring Emerging Travel Trends and Unique Hobby Inspirations</a></li>
-        <li><a href="/articles/going-green-vegan-vegetarian-travel.html" rel="author">Travel Guide | Going Green: The Rise of Vegan and Vegetarian Travel</a></li>
-        <li><a href="/articles/navigating-night-markets-food-lovers-guide.html" rel="author">Travel Guide | Navigating Night Markets: A Food Lover's Guide Around the World</a></li>
-        <li><a href="/articles/unveiling-magic-polar-expeditions.html" rel="author">Travel Guide | Unveiling the Magic of Polar Expeditions: Discovering Antarctica and the North Pole</a></li>
+        <li><a href="/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html" rel="author">Mastering Travel Flexibility: Tips and Inspiring Stories for Adventurous Journeys</a></li>
+        <li><a href="/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html" rel="author">Navigating Global Travel: Unique Destinations, Challenges, and Cultural Insights</a></li>
+        <li><a href="/articles/navigating-modern-travel-safety-tips-destinations-experiences.html" rel="author">Navigating Modern Travel: Safety Tips, Destinations, and Experiences</a></li>
+        <li><a href="/articles/unexpected-journeys-realities-modern-travel-experiences.html" rel="author">Unexpected Journeys and Realities: Exploring Modern Travel Experiences</a></li>
+        <li><a href="/articles/unforgettable-travel-experiences-top-destinations-2025.html" rel="author">Unforgettable Travel Experiences and Top Destinations in 2025</a></li>
+        <li><a href="/articles/architectural-marvels-modern-wonders-world.html" rel="author">Architectural Marvels: A Closer Look at Modern Wonders of the World</a></li>
+        <li><a href="/articles/cultural-immersion-experiences.html" rel="author">Cultural Immersion Experiences That Transcend the Tourist Traps</a></li>
+        <li><a href="/articles/best-safari-destinations.html" rel="author">Experiencing Wildlife: Best Safari Destinations Around the Globe</a></li>
+        <li><a href="/articles/exploring-emerging-travel-trends-unique-hobby-inspirations.html" rel="author">Exploring Emerging Travel Trends and Unique Hobby Inspirations</a></li>
+        <li><a href="/articles/going-green-vegan-vegetarian-travel.html" rel="author">Going Green: The Rise of Vegan and Vegetarian Travel</a></li>
+        <li><a href="/articles/navigating-night-markets-food-lovers-guide.html" rel="author">Navigating Night Markets: A Food Lover's Guide Around the World</a></li>
+        <li><a href="/articles/unveiling-magic-polar-expeditions.html" rel="author">Unveiling the Magic of Polar Expeditions: Discovering Antarctica and the North Pole</a></li>
       </ul>
       <p><a rel="nofollow" href="/about-us.html">Back to About Us</a></p>
     </main>

--- a/authors/david-agnew.html
+++ b/authors/david-agnew.html
@@ -28,16 +28,16 @@
       <p>David is a health and wellness writer with a background in journalism. He’s spent years researching the science behind mindful travel and adventure therapy, helping readers find balance and meaning on the road.</p>
       <h2>Articles by David Agnew</h2>
       <ul>
-        <li><a href="/articles/exploring-unique-destinations-travel-experiences-2025.html" rel="author">Audio Travel Guide | Exploring Unique Destinations and Travel Experiences Worldwide in 2025</a></li>
-        <li><a href="/articles/navigating-realities-wonders-modern-travel-2025.html" rel="author">Audio Travel Guide | Navigating Realities and Wonders of Modern Travel in 2025</a></li>
-        <li><a href="/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html" rel="author">Audio Travel Guide | Ultimate Travel Guide: Tips, Destinations, and Insider Experiences for 2025</a></li>
-        <li><a href="/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html" rel="author">Audio Travel Guide | Unforgettable Travel Stories and Expert Tips for 2025 Adventures</a></li>
-        <li><a href="/articles/exploring-untouched-forests.html" rel="author">Travel Guide | Into the Wild: Exploring the Untouched Forests of the World</a></li>
-        <li><a href="/articles/navigating-modern-travel-insights-experiences-tips-2025.html" rel="author">Travel Guide | Navigating Modern Travel: Insights, Experiences, and Tips for 2025</a></li>
-        <li><a href="/articles/touring-tropics-comprehensive-guide.html" rel="author">Travel Guide | Touring the Tropics: A Comprehensive Guide to Tropical Destinations</a></li>
-        <li><a href="/articles/transcontinental-trails-world.html" rel="author">Travel Guide | Transcontinental Trails: Experiencing the Great Hiking Trails Around the World</a></li>
-        <li><a href="/articles/traveling-without-trace.html" rel="author">Travel Guide | Traveling Without a Trace: A Guide to Leave No Trace Principles</a></li>
-        <li><a href="/articles/unplugged-adventures-travel-without-technology.html" rel="author">Travel Guide | Unplugged Adventures Experiencing Travel Without Technology</a></li>
+        <li><a href="/articles/exploring-unique-destinations-travel-experiences-2025.html" rel="author">Exploring Unique Destinations and Travel Experiences Worldwide in 2025</a></li>
+        <li><a href="/articles/navigating-realities-wonders-modern-travel-2025.html" rel="author">Navigating Realities and Wonders of Modern Travel in 2025</a></li>
+        <li><a href="/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html" rel="author">Ultimate Travel Guide: Tips, Destinations, and Insider Experiences for 2025</a></li>
+        <li><a href="/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html" rel="author">Unforgettable Travel Stories and Expert Tips for 2025 Adventures</a></li>
+        <li><a href="/articles/exploring-untouched-forests.html" rel="author">Into the Wild: Exploring the Untouched Forests of the World</a></li>
+        <li><a href="/articles/navigating-modern-travel-insights-experiences-tips-2025.html" rel="author">Navigating Modern Travel: Insights, Experiences, and Tips for 2025</a></li>
+        <li><a href="/articles/touring-tropics-comprehensive-guide.html" rel="author">Touring the Tropics: A Comprehensive Guide to Tropical Destinations</a></li>
+        <li><a href="/articles/transcontinental-trails-world.html" rel="author">Transcontinental Trails: Experiencing the Great Hiking Trails Around the World</a></li>
+        <li><a href="/articles/traveling-without-trace.html" rel="author">Traveling Without a Trace: A Guide to Leave No Trace Principles</a></li>
+        <li><a href="/articles/unplugged-adventures-travel-without-technology.html" rel="author">Unplugged Adventures Experiencing Travel Without Technology</a></li>
       </ul>
       <p><a rel="nofollow" href="/about-us.html">Back to About Us</a></p>
     </main>

--- a/authors/davina-blake.html
+++ b/authors/davina-blake.html
@@ -28,13 +28,13 @@
       <p>Davina covers the intersection of finance and travel, breaking down how to fund your adventures smartly. When she’s not crunching numbers, you’ll find her exploring off‑grid homestays with her camera in hand.</p>
       <h2>Articles by Davina Blake</h2>
       <ul>
-        <li><a href="/articles/visit-earth-extremities.html" rel="author">Travel Guide | A Visit to Earth’s Extremities: A Guide to Extreme Geographical Points</a></li>
-        <li><a href="/articles/dark-tourism-worlds-haunting-locations.html" rel="author">Travel Guide | Dark Tourism Visiting The World's Most Haunting Locations</a></li>
-        <li><a href="/articles/embracing-eco-tourism-sustainable-journey-costa-rica.html" rel="author">Travel Guide | Embracing Eco-Tourism A Sustainable Journey through Costa Rica</a></li>
-        <li><a href="/articles/hidden-gems-uncharted-travel-destinations.html" rel="author">Travel Guide | Hidden Gems Uncharted Travel Destinations Around the World</a></li>
-        <li><a href="/articles/pedal-paradises-destinations-cycling-enthusiasts.html" rel="author">Travel Guide | Pedal Through Paradises: Best Destinations for Cycling Enthusiasts</a></li>
-        <li><a href="/articles/roaming-roof-world-himalayas-guide.html" rel="author">Travel Guide | Roaming the Roof of the World: A Guide to the Himalayas</a></li>
-        <li><a href="/articles/top-10-hidden-gems-europe.html" rel="author">Travel Guide | Top 10 Hidden Gems to Explore in Europe</a></li>
+        <li><a href="/articles/visit-earth-extremities.html" rel="author">A Visit to Earth’s Extremities: A Guide to Extreme Geographical Points</a></li>
+        <li><a href="/articles/dark-tourism-worlds-haunting-locations.html" rel="author">Dark Tourism Visiting The World's Most Haunting Locations</a></li>
+        <li><a href="/articles/embracing-eco-tourism-sustainable-journey-costa-rica.html" rel="author">Embracing Eco-Tourism A Sustainable Journey through Costa Rica</a></li>
+        <li><a href="/articles/hidden-gems-uncharted-travel-destinations.html" rel="author">Hidden Gems Uncharted Travel Destinations Around the World</a></li>
+        <li><a href="/articles/pedal-paradises-destinations-cycling-enthusiasts.html" rel="author">Pedal Through Paradises: Best Destinations for Cycling Enthusiasts</a></li>
+        <li><a href="/articles/roaming-roof-world-himalayas-guide.html" rel="author">Roaming the Roof of the World: A Guide to the Himalayas</a></li>
+        <li><a href="/articles/top-10-hidden-gems-europe.html" rel="author">Top 10 Hidden Gems to Explore in Europe</a></li>
       </ul>
       <p><a rel="nofollow" href="/about-us.html">Back to About Us</a></p>
     </main>

--- a/authors/frank-axton.html
+++ b/authors/frank-axton.html
@@ -28,20 +28,20 @@
       <p>Frank writes about sustainable and immersive travel experiences. A former environmental engineer, he now hikes, kayaks, and documents eco‑friendly projects that give back to local communities.</p>
       <h2>Articles by Frank Axton</h2>
       <ul>
-        <li><a href="/articles/inspiring-travel-destinations-tips-2025-adventures.html" rel="author">Audio Travel Guide | Top Inspiring Travel Destinations and Tips for 2025 Adventures</a></li>
-        <li><a href="/articles/voyage-through-vineyards-global-wine-regions.html" rel="author">Travel Guide | A Voyage Through the Vineyards: Exploring Wine Regions Around the Globe</a></li>
-        <li><a href="/articles/exploring-worlds-historical-walking-routes.html" rel="author">Travel Guide | A Walk Through Time: Exploring World's Historical Walking Routes</a></li>
-        <li><a href="/articles/best-travel-apps.html" rel="author">Travel Guide | Best Travel Apps to Make Your Journey Easier</a></li>
-        <li><a href="/articles/digital-nomad-life-world.html" rel="author">Travel Guide | Digital Nomad Life: Exploring the World while Working Remotely</a></li>
-        <li><a href="/articles/exploring-arctic-travel-guide.html" rel="author">Travel Guide | Exploring the Arctic: A Travel Guide to Life in the Far North</a></li>
-        <li><a href="/articles/exploring-trending-travel-destinations-and-relaxing-hobby-ideas.html" rel="author">Travel Guide | Exploring Trending Travel Destinations and Relaxing Hobby Ideas</a></li>
-        <li><a href="/articles/exploring-unesco-sites.html" rel="author">Travel Guide | Exploring UNESCO World Heritage Sites: A Journey into History and Culture</a></li>
-        <li><a href="/articles/global-gastronomy-tasting-traditional-dishes-different-cultures.html" rel="author">Travel Guide | Global Gastronomy: Tasting Traditional Dishes Across Different Cultures</a></li>
-        <li><a href="/articles/top-surfing-destinations-world.html" rel="author">Travel Guide | Riding the Waves: Top Surfing Destinations Around the World</a></li>
-        <li><a href="/articles/african-safari-experience-a-journey-into-the-wild.html" rel="author">Travel Guide | The African Safari Experience: A Journey into the Wild</a></li>
-        <li><a href="/articles/traveling-through-taste-culinary-journey.html" rel="author">Travel Guide | Traveling Through Taste: A Culinary Journey Around the Globe</a></li>
-        <li><a href="/articles/ultimate-family-solo-travel-planning-tips-2025.html" rel="author">Travel Guide | Ultimate Family and Solo Travel Planning: Tips and Destinations for 2025</a></li>
-        <li><a href="/articles/voluntourism-impactful-travel.html" rel="author">Travel Guide | Voluntourism: Impactful Travel with a Cause</a></li>
+        <li><a href="/articles/inspiring-travel-destinations-tips-2025-adventures.html" rel="author">Top Inspiring Travel Destinations and Tips for 2025 Adventures</a></li>
+        <li><a href="/articles/voyage-through-vineyards-global-wine-regions.html" rel="author">A Voyage Through the Vineyards: Exploring Wine Regions Around the Globe</a></li>
+        <li><a href="/articles/exploring-worlds-historical-walking-routes.html" rel="author">A Walk Through Time: Exploring World's Historical Walking Routes</a></li>
+        <li><a href="/articles/best-travel-apps.html" rel="author">Best Travel Apps to Make Your Journey Easier</a></li>
+        <li><a href="/articles/digital-nomad-life-world.html" rel="author">Digital Nomad Life: Exploring the World while Working Remotely</a></li>
+        <li><a href="/articles/exploring-arctic-travel-guide.html" rel="author">Exploring the Arctic: A Travel Guide to Life in the Far North</a></li>
+        <li><a href="/articles/exploring-trending-travel-destinations-and-relaxing-hobby-ideas.html" rel="author">Exploring Trending Travel Destinations and Relaxing Hobby Ideas</a></li>
+        <li><a href="/articles/exploring-unesco-sites.html" rel="author">Exploring UNESCO World Heritage Sites: A Journey into History and Culture</a></li>
+        <li><a href="/articles/global-gastronomy-tasting-traditional-dishes-different-cultures.html" rel="author">Global Gastronomy: Tasting Traditional Dishes Across Different Cultures</a></li>
+        <li><a href="/articles/top-surfing-destinations-world.html" rel="author">Riding the Waves: Top Surfing Destinations Around the World</a></li>
+        <li><a href="/articles/african-safari-experience-a-journey-into-the-wild.html" rel="author">The African Safari Experience: A Journey into the Wild</a></li>
+        <li><a href="/articles/traveling-through-taste-culinary-journey.html" rel="author">Traveling Through Taste: A Culinary Journey Around the Globe</a></li>
+        <li><a href="/articles/ultimate-family-solo-travel-planning-tips-2025.html" rel="author">Ultimate Family and Solo Travel Planning: Tips and Destinations for 2025</a></li>
+        <li><a href="/articles/voluntourism-impactful-travel.html" rel="author">Voluntourism: Impactful Travel with a Cause</a></li>
       </ul>
       <p><a rel="nofollow" href="/about-us.html">Back to About Us</a></p>
     </main>

--- a/authors/lisa-crow.html
+++ b/authors/lisa-crow.html
@@ -28,17 +28,17 @@
       <p>Lisa is a health journalist turned travel writer. She specializes in wellness retreats around the globe, from Himalayan yoga ashrams to Mediterranean spa towns.</p>
       <h2>Articles by Lisa Crow</h2>
       <ul>
-        <li><a href="/articles/unforgettable-travel-journeys-unique-destinations-experiences.html" rel="author">Audio Travel Guide | Unforgettable Travel Journeys: Exploring Unique Destinations and Experiences</a></li>
-        <li><a href="/articles/behind-scenes-worlds-largest-festivals.html" rel="author">Travel Guide | Behind the Scenes: How the World's Largest Festivals are Organized</a></li>
-        <li><a href="/articles/beyond-hostels-hotels-unique-accommodations-adventurous-traveler.html" rel="author">Travel Guide | Beyond Hostels and Hotels: Unique Accommodations for the Adventurous Traveler</a></li>
-        <li><a href="/articles/eco-friendly-traveling-world-sustainably.html" rel="author">Travel Guide | Eco-Friendly Traveling How to See the World Sustainably</a></li>
-        <li><a href="/articles/glamping-world-luxury-tents-incredible-views.html" rel="author">Travel Guide | Glamping Around the World: Luxury Tents and Incredible Views</a></li>
-        <li><a href="/articles/historic-railways-world-journey.html" rel="author">Travel Guide | Historic Railways of the World: A Journey Through Time and Cultures</a></li>
-        <li><a href="/articles/travel-budget-tips.html" rel="author">Travel Guide | How to Travel on a Budget Without Missing Out</a></li>
-        <li><a href="/articles/river-cruises-europe.html" rel="author">Travel Guide | River Cruises: A Unique Way to Discover Hidden Gems of Europe</a></li>
-        <li><a href="/articles/sustainable-food-explorations.html" rel="author">Travel Guide | Sustainable Food Explorations: A Foodie's Guide to Eco-friendly Dining Worldwide</a></li>
-        <li><a href="/articles/exploring-worlds-most-religious-sites.html" rel="author">Travel Guide | The Sacred Journey: Exploring the World's Most Religious Sites</a></li>
-        <li><a href="/articles/timeless-timelines-history-iconic-landmarks.html" rel="author">Travel Guide | Timeless Timelines: Unraveling the History of Iconic Landmarks</a></li>
+        <li><a href="/articles/unforgettable-travel-journeys-unique-destinations-experiences.html" rel="author">Unforgettable Travel Journeys: Exploring Unique Destinations and Experiences</a></li>
+        <li><a href="/articles/behind-scenes-worlds-largest-festivals.html" rel="author">Behind the Scenes: How the World's Largest Festivals are Organized</a></li>
+        <li><a href="/articles/beyond-hostels-hotels-unique-accommodations-adventurous-traveler.html" rel="author">Beyond Hostels and Hotels: Unique Accommodations for the Adventurous Traveler</a></li>
+        <li><a href="/articles/eco-friendly-traveling-world-sustainably.html" rel="author">Eco-Friendly Traveling How to See the World Sustainably</a></li>
+        <li><a href="/articles/glamping-world-luxury-tents-incredible-views.html" rel="author">Glamping Around the World: Luxury Tents and Incredible Views</a></li>
+        <li><a href="/articles/historic-railways-world-journey.html" rel="author">Historic Railways of the World: A Journey Through Time and Cultures</a></li>
+        <li><a href="/articles/travel-budget-tips.html" rel="author">How to Travel on a Budget Without Missing Out</a></li>
+        <li><a href="/articles/river-cruises-europe.html" rel="author">River Cruises: A Unique Way to Discover Hidden Gems of Europe</a></li>
+        <li><a href="/articles/sustainable-food-explorations.html" rel="author">Sustainable Food Explorations: A Foodie's Guide to Eco-friendly Dining Worldwide</a></li>
+        <li><a href="/articles/exploring-worlds-most-religious-sites.html" rel="author">The Sacred Journey: Exploring the World's Most Religious Sites</a></li>
+        <li><a href="/articles/timeless-timelines-history-iconic-landmarks.html" rel="author">Timeless Timelines: Unraveling the History of Iconic Landmarks</a></li>
       </ul>
       <p><a rel="nofollow" href="/about-us.html">Back to About Us</a></p>
     </main>

--- a/authors/shamina-cody.html
+++ b/authors/shamina-cody.html
@@ -28,17 +28,17 @@
       <p>Shamina explores the cultural side of travel—festivals, street food and local arts. A lifelong entertainer, she weaves personal anecdotes into every guide she writes.</p>
       <h2>Articles by Shamina Cody</h2>
       <ul>
-        <li><a href="/articles/discover-transformative-travel-stories-trending-destinations.html" rel="author">Audio Travel Guide | Discover Transformative Travel Stories and Top Trending Destinations</a></li>
-        <li><a href="/articles/explore-enchanting-destinations-smart-travel-planning-2025.html" rel="author">Audio Travel Guide | Explore Enchanting Destinations and Smart Travel Planning Tips for 2025</a></li>
-        <li><a href="/articles/exploring-new-horizons-top-travel-tips-destinations-2025.html" rel="author">Audio Travel Guide | Exploring New Horizons: Top Travel Tips and Destinations for 2025</a></li>
-        <li><a href="/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html" rel="author">Audio Travel Guide | Navigating Modern Travel: Experiences, Challenges, and Emerging Destinations</a></li>
-        <li><a href="/articles/navigating-solo-journeys-travel-challenges-2025.html" rel="author">Audio Travel Guide | Navigating Solo Journeys and Travel Challenges in 2025</a></li>
-        <li><a href="/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html" rel="author">Audio Travel Guide | Navigating Travel Experiences: Tips, Challenges, and Inspiring Journeys</a></li>
-        <li><a href="/articles/unforgettable-travel-adventures-inspiring-journeys-world.html" rel="author">Audio Travel Guide | Unforgettable Travel Adventures and Inspiring Journeys Around the World</a></li>
-        <li><a href="/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html" rel="author">Audio Travel Guide | Unforgettable Travel Adventures: Exploring Unique Destinations Safely</a></li>
-        <li><a href="/articles/exploring-authentic-travel-experiences-hidden-gems-challenges.html" rel="author">Travel Guide | Exploring Authentic Travel Experiences: From Hidden Gems to Real Challenges</a></li>
-        <li><a href="/articles/sanctuaries-sky-worlds-picturesque-mountain-retreats.html" rel="author">Travel Guide | Sanctuaries in the Sky: World's Most Picturesque Mountain Retreats</a></li>
-        <li><a href="/articles/solo-travel-safety-guide.html" rel="author">Travel Guide | The Ultimate Guide to Solo Travel Safety</a></li>
+        <li><a href="/articles/discover-transformative-travel-stories-trending-destinations.html" rel="author">Discover Transformative Travel Stories and Top Trending Destinations</a></li>
+        <li><a href="/articles/explore-enchanting-destinations-smart-travel-planning-2025.html" rel="author">Explore Enchanting Destinations and Smart Travel Planning Tips for 2025</a></li>
+        <li><a href="/articles/exploring-new-horizons-top-travel-tips-destinations-2025.html" rel="author">Exploring New Horizons: Top Travel Tips and Destinations for 2025</a></li>
+        <li><a href="/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html" rel="author">Navigating Modern Travel: Experiences, Challenges, and Emerging Destinations</a></li>
+        <li><a href="/articles/navigating-solo-journeys-travel-challenges-2025.html" rel="author">Navigating Solo Journeys and Travel Challenges in 2025</a></li>
+        <li><a href="/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html" rel="author">Navigating Travel Experiences: Tips, Challenges, and Inspiring Journeys</a></li>
+        <li><a href="/articles/unforgettable-travel-adventures-inspiring-journeys-world.html" rel="author">Unforgettable Travel Adventures and Inspiring Journeys Around the World</a></li>
+        <li><a href="/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html" rel="author">Unforgettable Travel Adventures: Exploring Unique Destinations Safely</a></li>
+        <li><a href="/articles/exploring-authentic-travel-experiences-hidden-gems-challenges.html" rel="author">Exploring Authentic Travel Experiences: From Hidden Gems to Real Challenges</a></li>
+        <li><a href="/articles/sanctuaries-sky-worlds-picturesque-mountain-retreats.html" rel="author">Sanctuaries in the Sky: World's Most Picturesque Mountain Retreats</a></li>
+        <li><a href="/articles/solo-travel-safety-guide.html" rel="author">The Ultimate Guide to Solo Travel Safety</a></li>
       </ul>
       <p><a rel="nofollow" href="/about-us.html">Back to About Us</a></p>
     </main>

--- a/authors/susanna-lem.html
+++ b/authors/susanna-lem.html
@@ -28,10 +28,10 @@
       <p>Susanna writes both finance and travel pieces. She’s best known for her deep dives into budget‑friendly itineraries and creative ways to see the world without breaking the bank.</p>
       <h2>Articles by Susanna Lem</h2>
       <ul>
-        <li><a href="/articles/unplanned-journeys-travel-realities-insights.html" rel="author">Audio Travel Guide | Unplanned Journeys and Travel Realities: Insights for Savvy Adventurers</a></li>
-        <li><a href="/articles/exploring-scottish-highlands.html" rel="author">Travel Guide | Exploring the Highlands: A Guide to the Scottish Highlands</a></li>
-        <li><a href="/articles/travel-hacks-tips-save-money-time.html" rel="author">Travel Guide | Travel Hacks Essential Tips to Save Money and Time While Traveling</a></li>
-        <li><a href="/articles/traveling-twist-unique-festivals-globe.html" rel="author">Travel Guide | Traveling with a Twist – Unique Festivals Around the Globe</a></li>
+        <li><a href="/articles/unplanned-journeys-travel-realities-insights.html" rel="author">Unplanned Journeys and Travel Realities: Insights for Savvy Adventurers</a></li>
+        <li><a href="/articles/exploring-scottish-highlands.html" rel="author">Exploring the Highlands: A Guide to the Scottish Highlands</a></li>
+        <li><a href="/articles/travel-hacks-tips-save-money-time.html" rel="author">Travel Hacks Essential Tips to Save Money and Time While Traveling</a></li>
+        <li><a href="/articles/traveling-twist-unique-festivals-globe.html" rel="author">Traveling with a Twist – Unique Festivals Around the Globe</a></li>
       </ul>
       <p><a rel="nofollow" href="/about-us.html">Back to About Us</a></p>
     </main>


### PR DESCRIPTION
## Summary
- Remove redundant "Audio Travel Guide" and "Travel Guide" prefixes from article links on author pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b02e92f74c83299856ebdfa296f04e