### PR TITLE
feat: add varied grid layout

### DIFF
--- a/assets/scripts/index.mjs
+++ b/assets/scripts/index.mjs
@@ -1,1 +1,79 @@
-const loading=document.getElementById("loading"),showMoreButton=document.getElementById("show-more-button");async function renderPosts(){loading.style.display="block",showMoreButton.style.display="none";const e=await fetch("assets/search.json"),n=await e.json(),t=document.getElementById("latest");t.innerHTML="",n.sort((e,n)=>new Date(n.publishDate).getTime()-new Date(e.publishDate).getTime()).forEach(e=>{const n=new Date(e.publishDate).toLocaleDateString("en-US",{year:"numeric",month:"long",day:"numeric"}),i=document.createElement("div");i.className="card",i.innerHTML=`\n    <a\n        aria-label="${e.imageAlt}"\n        href="${e.url}">\n        <picture>\n            <img\n                src="${e.imageUrl}"\n                srcset="\n                ${e.imageUrl}&dpr=2 2x,\n                ${e.imageUrl} 1x\n                "\n                sizes="(min-width:38rem) 38rem, 100vw"\n                alt="${e.imageAlt}"\n                loading="lazy"\n                decoding="async"\n                width="608"\n                height="227"\n            />\n        </picture>\n    </a>\n\n    <h3><a href="${e.url}">${e.title}</a></h3>\n\n     <div id="published">\n        Published:\n        <em\n        ><time itemprop="datePublished" datetime="${e.publishDate}">\n            ${n}</time\n        ></em\n        >\n    </div>\n\n  <p>${e.description}</p>\n`,t.appendChild(i)}),loading.style.display="none"}showMoreButton.addEventListener("click",renderPosts);
+const loading = document.getElementById("loading");
+const showMoreButton = document.getElementById("show-more-button");
+
+function applyRandomLayout(cards) {
+  cards.forEach((card) => {
+    card.classList.remove("card--wide", "card--tall", "card--big");
+    const rand = Math.random();
+    if (rand < 0.25) {
+      card.classList.add("card--big");
+    } else if (rand < 0.5) {
+      card.classList.add("card--wide");
+    } else if (rand < 0.75) {
+      card.classList.add("card--tall");
+    }
+  });
+}
+
+applyRandomLayout(document.querySelectorAll(".posts .card"));
+
+async function renderPosts() {
+  loading.style.display = "block";
+  showMoreButton.style.display = "none";
+  const response = await fetch("assets/search.json");
+  const posts = await response.json();
+  const container = document.getElementById("latest");
+  container.innerHTML = "";
+  posts
+    .sort(
+      (a, b) =>
+        new Date(b.publishDate).getTime() - new Date(a.publishDate).getTime()
+    )
+    .forEach((post) => {
+      const published = new Date(post.publishDate).toLocaleDateString(
+        "en-US",
+        { year: "numeric", month: "long", day: "numeric" }
+      );
+      const card = document.createElement("div");
+      card.className = "card";
+      card.innerHTML = `
+    <a
+        aria-label="${post.imageAlt}"
+        href="${post.url}"
+    >
+        <picture>
+            <img
+                src="${post.imageUrl}"
+                srcset="
+                ${post.imageUrl}&dpr=2 2x,
+                ${post.imageUrl} 1x
+                "
+                sizes="(min-width:38rem) 38rem, 100vw"
+                alt="${post.imageAlt}"
+                loading="lazy"
+                decoding="async"
+                width="608"
+                height="227"
+            />
+        </picture>
+    </a>
+
+    <h3><a href="${post.url}">${post.title}</a></h3>
+
+     <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="${post.publishDate}">
+            ${published}</time
+        ></em>
+    </div>
+
+  <p>${post.description}</p>
+`;
+      container.appendChild(card);
+    });
+  applyRandomLayout(container.querySelectorAll(".card"));
+  loading.style.display = "none";
+}
+
+showMoreButton.addEventListener("click", renderPosts);
+

--- a/assets/styles/index.css
+++ b/assets/styles/index.css
@@ -1,1 +1,158 @@
-:root{--max-width:120ch}body>footer,main{max-width:120ch;max-width:var(--max-width)}search{width:max(10rem,min(25rem,30rem))}search input{border-radius:.5rem;border-width:.1rem;padding:1rem;width:100%}section:not(first-of-type){margin-top:3rem}#header-container{align-items:center;display:flex;gap:2rem;justify-content:space-between;margin:0 auto;max-width:120ch;max-width:var(--max-width);padding:1rem}#loading{display:none;margin-bottom:2rem;margin-top:2rem;padding-left:1.8em;position:relative}#loading:before{animation:spin .8s linear infinite;border:3px solid var(--color-bg);border-radius:50%;border-top-color:var(--color-primary);content:"";height:1.2em;left:0;margin-top:-.6em;position:absolute;top:50%;width:1.2em}.divider{margin:0}.posts{display:flex;flex-wrap:wrap;gap:2rem;margin-top:2rem}.posts .card img{height:12rem}.posts .card h3,.posts .card p{display:-webkit-box;-webkit-box-orient:vertical;line-height:1.5em;overflow:hidden;text-overflow:ellipsis;white-space:normal;-webkit-line-clamp:3;line-clamp:3;max-height:4.5em}.posts .card h3{max-height:3em}#show-more-button{margin:2rem auto;width:100%}.card{box-shadow:2px 2px 5px var(--color-shadow);flex:1 1 18rem}.card img:hover{transform:scale(1.2)}.card h3{margin-bottom:1rem;margin-top:1rem}.card h3,.card p{padding-left:1rem;padding-right:1rem}.card p{margin:0;padding-bottom:1rem}.card #published{margin-bottom:.5rem;padding-left:1rem;padding-right:1rem}@keyframes spin{to{transform:rotate(1turn)}}@media (prefers-reduced-motion:reduce){#loading:before{animation:none}}@media screen and (min-width:var(--max-width )){#header-container{padding:0}}
+:root {
+  --max-width: 120ch;
+}
+
+body > footer,
+main {
+  max-width: var(--max-width);
+}
+
+search {
+  width: max(10rem, min(25rem, 30rem));
+}
+
+search input {
+  border-radius: 0.5rem;
+  border-width: 0.1rem;
+  padding: 1rem;
+  width: 100%;
+}
+
+section:not(first-of-type) {
+  margin-top: 3rem;
+}
+
+#header-container {
+  align-items: center;
+  display: flex;
+  gap: 2rem;
+  justify-content: space-between;
+  margin: 0 auto;
+  max-width: var(--max-width);
+  padding: 1rem;
+}
+
+#loading {
+  display: none;
+  margin-bottom: 2rem;
+  margin-top: 2rem;
+  padding-left: 1.8em;
+  position: relative;
+}
+
+#loading:before {
+  animation: spin 0.8s linear infinite;
+  border: 3px solid var(--color-bg);
+  border-radius: 50%;
+  border-top-color: var(--color-primary);
+  content: "";
+  height: 1.2em;
+  left: 0;
+  margin-top: -0.6em;
+  position: absolute;
+  top: 50%;
+  width: 1.2em;
+}
+
+.divider {
+  margin: 0;
+}
+
+.posts {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-auto-rows: 12rem;
+  grid-auto-flow: dense;
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.posts .card img {
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
+}
+
+.posts .card h3,
+.posts .card p {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  line-height: 1.5em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  max-height: 4.5em;
+}
+
+.posts .card h3 {
+  max-height: 3em;
+}
+
+#show-more-button {
+  margin: 2rem auto;
+  width: 100%;
+}
+
+.card {
+  box-shadow: 2px 2px 5px var(--color-shadow);
+}
+
+.card img:hover {
+  transform: scale(1.2);
+}
+
+.card h3 {
+  margin-bottom: 1rem;
+  margin-top: 1rem;
+}
+
+.card h3,
+.card p {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.card p {
+  margin: 0;
+  padding-bottom: 1rem;
+}
+
+.card #published {
+  margin-bottom: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.card--wide {
+  grid-column: span 2;
+}
+
+.card--tall {
+  grid-row: span 2;
+}
+
+.card--big {
+  grid-column: span 2;
+  grid-row: span 2;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #loading:before {
+    animation: none;
+  }
+}
+
+@media screen and (min-width: var(--max-width)) {
+  #header-container {
+    padding: 0;
+  }
+}
+


### PR DESCRIPTION
## Summary
- use CSS grid for posts with support for wide and tall cards
- randomly assign layout classes to cards when page loads and when loading more posts

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b04fc8ff6c832999996bbdd9d6f82a