### PR TITLE
Load more shows 10 items per click

### DIFF
--- a/assets/scripts/index.mjs
+++ b/assets/scripts/index.mjs
@@ -1,1 +1,82 @@
-const loading=document.getElementById("loading"),showMoreButton=document.getElementById("show-more-button");async function renderPosts(){loading.style.display="block",showMoreButton.style.display="none";const e=await fetch("assets/search.json"),n=await e.json(),t=document.getElementById("latest");t.innerHTML="",n.sort((e,n)=>new Date(n.publishDate).getTime()-new Date(e.publishDate).getTime()).forEach(e=>{const n=new Date(e.publishDate).toLocaleDateString("en-US",{year:"numeric",month:"long",day:"numeric"}),i=document.createElement("div");i.className="card",i.innerHTML=`\n    <a\n        aria-label="${e.imageAlt}"\n        href="${e.url}"\n    >\n        <picture>\n            <img\n                src="${e.imageUrl}"\n                srcset="\n                ${e.imageUrl}&dpr=2 2x,\n                ${e.imageUrl} 1x\n                "\n                sizes="(min-width:38rem) 38rem, 100vw"\n                alt="${e.imageAlt}"\n                loading="lazy"\n                decoding="async"\n                width="608"\n                height="227"\n            />\n        </picture>\n    </a>\n\n    <h3><a href="${e.url}">${e.title}</a></h3>\n\n     <div id="published">\n        Published:\n        <em><time itemprop="datePublished" datetime="${e.publishDate}">\n            ${n}</time\n        ></em>\n    </div>\n\n  <p>${e.description}</p>\n`,t.appendChild(i)}),loading.style.display="none"}showMoreButton.addEventListener("click",renderPosts);
+const loading = document.getElementById("loading");
+const showMoreButton = document.getElementById("show-more-button");
+const latest = document.getElementById("latest");
+
+let allPosts = [];
+let loadedCount = latest.children.length;
+let isFetching = false;
+
+async function loadMore() {
+  if (isFetching) return;
+  isFetching = true;
+  loading.style.display = "block";
+  showMoreButton.disabled = true;
+
+  if (allPosts.length === 0) {
+    const response = await fetch("assets/search.json");
+    allPosts = await response.json();
+    allPosts.sort(
+      (a, b) =>
+        new Date(b.publishDate).getTime() -
+        new Date(a.publishDate).getTime()
+    );
+  }
+
+  const nextPosts = allPosts.slice(loadedCount, loadedCount + 10);
+
+  nextPosts.forEach((post) => {
+    const published = new Date(post.publishDate).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+
+    const card = document.createElement("div");
+    card.className = "card";
+    card.innerHTML = `
+    <a
+        aria-label="${post.imageAlt}"
+        href="${post.url}"
+    >
+        <picture>
+            <img
+                src="${post.imageUrl}"
+                srcset="
+                ${post.imageUrl}&dpr=2 2x,
+                ${post.imageUrl} 1x
+                "
+                sizes="(min-width:38rem) 38rem, 100vw"
+                alt="${post.imageAlt}"
+                loading="lazy"
+                decoding="async"
+                width="608"
+                height="227"
+            />
+        </picture>
+    </a>
+
+    <h3><a href="${post.url}">${post.title}</a></h3>
+
+     <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="${post.publishDate}">
+            ${published}</time
+        ></em>
+    </div>
+
+  <p>${post.description}</p>
+`;
+    latest.appendChild(card);
+  });
+
+  loadedCount += nextPosts.length;
+  loading.style.display = "none";
+  showMoreButton.disabled = false;
+  isFetching = false;
+
+  if (loadedCount >= allPosts.length) {
+    showMoreButton.style.display = "none";
+  }
+}
+
+showMoreButton.addEventListener("click", loadMore);


### PR DESCRIPTION
## Summary
- Update load-more logic to append 10 posts per click, keeping the button visible until all articles appear

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0647d294883299b1039d093a98abf