### PR TITLE
Embed latest articles directly in index

### DIFF
--- a/assets/scripts/index.mjs
+++ b/assets/scripts/index.mjs
@@ -1,1 +1,89 @@
-window.addEventListener("DOMContentLoaded",()=>{const e=document.getElementById("loading"),n=document.getElementById("show-more-button"),t=document.getElementById("latest-featured"),i=document.getElementById("latest-grid");if(e&&n&&t&&i){let a=[],l=t.querySelectorAll(".card").length+i.querySelectorAll(".card").length,d=!1;n.addEventListener("click",async function(){if(d)return;if(d=!0,e.style.display="block",n.disabled=!0,0===a.length){const e=await fetch("assets/search.json");a=await e.json(),a.sort((e,n)=>new Date(n.publishDate).getTime()-new Date(e.publishDate).getTime())}const t=a.slice(l,l+10);t.forEach(e=>{const n=new Date(e.publishDate).toLocaleDateString("en-US",{year:"numeric",month:"long",day:"numeric"}),t=document.createElement("div");t.className="card",t.innerHTML=`\n    <a\n     aria-label="${e.imageAlt}"\n        href="${e.url}"\n    >\n        <picture>\n            <img\n                src="${e.imageUrl}"\n                srcset="\n                ${e.imageUrl} 200w,\n                ${e.imageUrl}&dpr=2 400w\n    "\n                sizes="(min-width:76rem) 18rem, 100vw"\n                alt="${e.imageAlt}"\n                loading="lazy"\n                decoding="async"\n                width="200"\n                height="75"\n            />\n        </picture>\n    </a>\n\n    <h3><a href="${e.url}">${e.title}</a></h3>\n\n     <div id="published">\n        Published:\n        <em><time itemprop="datePublished" datetime="${e.publishDate}">\n            ${n}</time\n        ></em>\n    </div>\n\n  <p>${e.description}</p>\n`,i.appendChild(t)}),l+=t.length,e.style.display="none",n.disabled=!1,d=!1,l>=a.length&&(n.style.display="none")})}});
+window.addEventListener("DOMContentLoaded", () => {
+  const loading = document.getElementById("loading");
+  const showMoreButton = document.getElementById("show-more-button");
+  const featured = document.getElementById("latest-featured");
+  const grid = document.getElementById("latest-grid");
+
+  if (loading && showMoreButton && featured && grid) {
+    let articles = [];
+    let loadedCount =
+      featured.querySelectorAll(".card").length +
+      grid.querySelectorAll(".card").length;
+    let isLoading = false;
+
+    async function loadMore(count) {
+      if (isLoading) return;
+      isLoading = true;
+      loading.style.display = "block";
+      showMoreButton.disabled = true;
+
+      if (articles.length === 0) {
+        const response = await fetch("assets/search.json");
+        articles = await response.json();
+        articles.sort(
+          (a, b) =>
+            new Date(b.publishDate).getTime() -
+            new Date(a.publishDate).getTime()
+        );
+      }
+
+      const next = articles.slice(loadedCount, loadedCount + count);
+      next.forEach((article) => {
+        const published = new Date(article.publishDate).toLocaleDateString(
+          "en-US",
+          { year: "numeric", month: "long", day: "numeric" }
+        );
+        const card = document.createElement("div");
+        card.className = "card";
+        card.innerHTML = `
+    <a
+     aria-label="${article.imageAlt}"
+        href="${article.url}"
+    >
+        <picture>
+            <img
+                src="${article.imageUrl}"
+                srcset="
+                ${article.imageUrl} 200w,
+                ${article.imageUrl}&dpr=2 400w
+    "
+                sizes="(min-width:76rem) 18rem, 100vw"
+                alt="${article.imageAlt}"
+        loading="lazy"
+                decoding="async"
+                width="200"
+                height="75"
+            />
+        </picture>
+    </a>
+
+    <h3><a href="${article.url}">${article.title}</a></h3>
+
+     <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="${article.publishDate}">
+            ${published}</time
+        ></em>
+    </div>
+
+  <p>${article.description}</p>
+`;
+        grid.appendChild(card);
+      });
+
+      loadedCount += next.length;
+      loading.style.display = "none";
+      showMoreButton.disabled = false;
+      isLoading = false;
+
+      if (loadedCount >= articles.length) {
+        showMoreButton.style.display = "none";
+      }
+    }
+
+    // Load enough articles upfront to fill the initial layout
+    loadMore(10);
+
+    showMoreButton.addEventListener("click", () => loadMore(10));
+  }
+});

--- a/assets/styles/index.css
+++ b/assets/styles/index.css
@@ -1,1 +1,171 @@
-:root{--max-width:120ch}body>footer,main{max-width:120ch;max-width:var(--max-width)}search{width:max(10rem,min(25rem,30rem))}search input{border-radius:.5rem;border-width:.1rem;padding:1rem;width:100%}section:not(first-of-type){margin-top:3rem}#header-container{align-items:center;display:flex;gap:2rem;justify-content:space-between;margin:0 auto;max-width:120ch;max-width:var(--max-width);padding:1rem}#loading{display:none;margin-bottom:2rem;margin-top:2rem;padding-left:1.8em;position:relative}#loading:before{animation:spin .8s linear infinite;border:3px solid var(--color-bg);border-radius:50%;border-top-color:var(--color-primary);content:"";height:1.2em;left:0;margin-top:-.6em;position:absolute;top:50%;width:1.2em}.divider{margin:0}.posts{display:flex;gap:2rem;margin-top:2rem}.posts:not(#latest-featured):not(#latest-grid) .card{margin-bottom:2rem}.posts:not(#latest-featured):not(#latest-grid) .card picture{height:100%;max-height:12rem}#latest-featured{display:grid;grid-template-columns:2fr 1fr;grid-gap:2rem;gap:2rem}#latest-featured .side-list{display:flex;flex-direction:column;gap:2rem}#latest-featured .card--big{grid-column:1;grid-row:span 2}#latest-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(18rem,1fr));grid-gap:2rem;gap:2rem}.posts .card img{height:12rem;-o-object-fit:cover;object-fit:cover;width:100%}.posts .card h3,.posts .card p{display:-webkit-box;-webkit-box-orient:vertical;line-height:1.5em;overflow:hidden;text-overflow:ellipsis;white-space:normal;-webkit-line-clamp:3;line-clamp:3;max-height:4.5em}.posts .card h3{max-height:3em}#show-more-button{margin:2rem auto;width:100%}.card{background-color:#fff;box-shadow:2px 2px 5px var(--color-shadow);padding-bottom:2rem}.card img:hover{transform:scale(1.2)}.card h3{margin-bottom:1rem;margin-top:1rem}.card h3,.card p{padding-left:1rem;padding-right:1rem}.card p{margin:0;padding-bottom:1rem}.card #published{margin-bottom:.5rem;padding-left:1rem;padding-right:1rem}.card--wide{grid-column:span 2}.card--big,.card--tall{grid-row:span 2}.card--big{grid-column:span 2}@media screen and (min-width:var(--max-width )){.posts:not(#latest-featured):not(#latest-grid){display:flex;gap:2rem;overflow-x:auto}.posts:not(#latest-featured):not(#latest-grid) .card{flex:0 0 18rem;margin-bottom:0}}@keyframes spin{to{transform:rotate(1turn)}}@media (prefers-reduced-motion:reduce){#loading:before{animation:none}}@media screen and (min-width:var(--max-width )){#header-container{padding:0}}
+:root {
+  --max-width: 120ch;
+}
+
+body > footer,
+main {
+  max-width: 120ch;
+  max-width: var(--max-width);
+}
+
+search {
+  width: max(10rem, min(25rem, 30rem));
+}
+
+search input {
+  border-radius: 0.5rem;
+  border-width: 0.1rem;
+  padding: 1rem;
+  width: 100%;
+}
+
+section:not(first-of-type) {
+  margin-top: 3rem;
+}
+
+#header-container {
+  align-items: center;
+  display: flex;
+  gap: 2rem;
+  justify-content: space-between;
+  margin: 0 auto;
+  max-width: 120ch;
+  max-width: var(--max-width);
+  padding: 1rem;
+}
+
+.divider {
+  margin: 0;
+}
+
+.posts {
+  display: flex;
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.posts:not(#latest-featured):not(#latest-grid) .card {
+  margin-bottom: 2rem;
+}
+
+.posts:not(#latest-featured):not(#latest-grid) .card picture {
+  height: 100%;
+  max-height: 12rem;
+}
+
+#latest-featured {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  grid-gap: 2rem;
+  gap: 2rem;
+}
+
+#latest-featured .side-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+#latest-featured .card--big {
+  grid-column: 1;
+  grid-row: span 2;
+}
+
+#latest-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  grid-gap: 2rem;
+  gap: 2rem;
+}
+
+.posts .card img {
+  height: 12rem;
+  object-fit: cover;
+  width: 100%;
+}
+
+.posts .card h3,
+.posts .card p {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  line-height: 1.5em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  max-height: 4.5em;
+}
+
+.posts .card h3 {
+  max-height: 3em;
+}
+
+.card {
+  background-color: #fff;
+  box-shadow: 2px 2px 5px var(--color-shadow);
+  padding-bottom: 2rem;
+}
+
+.card img:hover {
+  transform: scale(1.2);
+}
+
+.card h3 {
+  margin-bottom: 1rem;
+  margin-top: 1rem;
+}
+
+.card h3,
+.card p {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.card p {
+  margin: 0;
+  padding-bottom: 1rem;
+}
+
+.card #published {
+  margin-bottom: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.card--wide {
+  grid-column: span 2;
+}
+
+.card--big,
+.card--tall {
+  grid-row: span 2;
+}
+
+.card--big {
+  grid-column: span 2;
+}
+
+@media screen and (min-width: var(--max-width)) {
+  .posts:not(#latest-featured):not(#latest-grid) {
+    display: flex;
+    gap: 2rem;
+    overflow-x: auto;
+  }
+  .posts:not(#latest-featured):not(#latest-grid) .card {
+    flex: 0 0 18rem;
+    margin-bottom: 0;
+  }
+}
+
+@media screen and (min-width: 76rem) {
+  #latest-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media screen and (min-width: var(--max-width)) {
+  #header-container {
+    padding: 0;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -83,11 +83,7 @@
     <link rel="stylesheet" href="assets/styles/style.css" />
     <link rel="stylesheet" href="assets/styles/index.css" />
 
-    <script
-      type="module"
-      src="assets/scripts/index.mjs"
-      crossorigin="anonymous"
-    ></script>
+    <!-- Removed automatic article loader -->
   </head>
 
   <body>
@@ -576,10 +572,291 @@
           </div>
         </div>
 
-        <div class="posts" id="latest-grid"></div>
+        <div class="posts" id="latest-grid">
+          <div class="card">
+            <a
+              aria-label="a bus driving through a canyon"
+              href="/articles/explore-enchanting-destinations-smart-travel-planning-2025.html"
+            >
+              <picture>
+                <img
+                  src="https://images.unsplash.com/photo-1669399554927-cc38ca6bc3ba?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlbmNoYW50aW5nJTIwdHJhdmVsJTIwZGVzdGluYXRpb25zJTIwMjAyNXxlbnwwfDB8fHwxNzU1MjYyODM2fDA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
+                  srcset="https://images.unsplash.com/photo-1669399554927-cc38ca6bc3ba?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlbmNoYW50aW5nJTIwdHJhdmVsJTIwZGVzdGluYXRpb25zJTIwMjAyNXxlbnwwfDB8fHwxNzU1MjYyODM2fDA&ixlib=rb-4.1.0&q=80&w=1080?w=200 200w, https://images.unsplash.com/photo-1669399554927-cc38ca6bc3ba?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlbmNoYW50aW5nJTIwdHJhdmVsJTIwZGVzdGluYXRpb25zJTIwMjAyNXxlbnwwfDB8fHwxNzU1MjYyODM2fDA&ixlib=rb-4.1.0&q=80&w=1080?w=200&dpr=2 400w"
+                  sizes="(min-width:76rem) 18rem, 100vw"
+                  alt="a bus driving through a canyon"
+                  loading="lazy"
+                  decoding="async"
+                  width="200"
+                  height="75"
+                />
+              </picture>
+            </a>
+            <h3>
+              <a href="/articles/explore-enchanting-destinations-smart-travel-planning-2025.html"
+                >Explore Enchanting Destinations and Smart Travel Planning Tips for
+                2025</a
+              >
+            </h3>
+            <div id="published">
+              Published:
+              <em
+                ><time itemprop="datePublished" datetime="2025-08-15"
+                  >August 15, 2025</time
+                ></em
+              >
+            </div>
+            <p>
+              Discover the most enchanting travel destinations set to captivate
+              adventurers in 2025, paired with smart planning tips to make every
+              trip seamless. From unique locales to insider advice, this guide
+              will inspire your next unforgettable journey.
+            </p>
+          </div>
 
-        <div id="loading">Loading...</div>
-        <button id="show-more-button">Show More</button>
+          <div class="card">
+            <a
+              aria-label="man wearing white shirt overlooking on white clouds"
+              href="/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html"
+            >
+              <picture>
+                <img
+                  src="https://images.unsplash.com/photo-1612257998531-70e0d0a15f6d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTUyNjI0OTJ8MA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
+                  srcset="https://images.unsplash.com/photo-1612257998531-70e0d0a15f6d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTUyNjI0OTJ8MA&ixlib=rb-4.1.0&q=80&w=1080?w=200 200w, https://images.unsplash.com/photo-1612257998531-70e0d0a15f6d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTUyNjI0OTJ8MA&ixlib=rb-4.1.0&q=80&w=1080?w=200&dpr=2 400w"
+                  sizes="(min-width:76rem) 18rem, 100vw"
+                  alt="man wearing white shirt overlooking on white clouds"
+                  loading="lazy"
+                  decoding="async"
+                  width="200"
+                  height="75"
+                />
+              </picture>
+            </a>
+            <h3>
+              <a href="/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html"
+                >Navigating Modern Travel: Experiences, Challenges, and Emerging
+                Destinations</a
+              >
+            </h3>
+            <div id="published">
+              Published:
+              <em
+                ><time itemprop="datePublished" datetime="2025-08-15"
+                  >August 15, 2025</time
+                ></em
+              >
+            </div>
+            <p>
+              Navigating the world of modern travel introduces a mix of exciting
+              experiences and unexpected challenges. This article begins by
+              exploring key travel experiences in 2025 that set the stage for
+              contemporary journeys.
+            </p>
+          </div>
+
+          <div class="card">
+            <a
+              aria-label="green trees near body of water during daytime"
+              href="/articles/unforgettable-travel-journeys-unique-destinations-experiences.html"
+            >
+              <picture>
+                <img
+                  src="https://images.unsplash.com/photo-1609464528647-bd84b5b6b461?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxleG90aWMlMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnN8ZW58MHwwfHx8MTc1NTI0NDcyMnww&ixlib=rb-4.1.0&q=80&w=1080?w=200"
+                  srcset="https://images.unsplash.com/photo-1609464528647-bd84b5b6b461?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxleG90aWMlMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnN8ZW58MHwwfHx8MTc1NTI0NDcyMnww&ixlib=rb-4.1.0&q=80&w=1080?w=200 200w, https://images.unsplash.com/photo-1609464528647-bd84b5b6b461?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxleG90aWMlMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnN8ZW58MHwwfHx8MTc1NTI0NDcyMnww&ixlib=rb-4.1.0&q=80&w=1080?w=200&dpr=2 400w"
+                  sizes="(min-width:76rem) 18rem, 100vw"
+                  alt="green trees near body of water during daytime"
+                  loading="lazy"
+                  decoding="async"
+                  width="200"
+                  height="75"
+                />
+              </picture>
+            </a>
+            <h3>
+              <a href="/articles/unforgettable-travel-journeys-unique-destinations-experiences.html"
+                >Unforgettable Travel Journeys: Exploring Unique Destinations and
+                Experiences</a
+              >
+            </h3>
+            <div id="published">
+              Published:
+              <em
+                ><time itemprop="datePublished" datetime="2025-08-15"
+                  >August 15, 2025</time
+                ></em
+              >
+            </div>
+            <p>
+              Embark on unforgettable travel journeys that lead you to unique
+              destinations and extraordinary experiences around the globe. From
+              discovering hidden gems to planning your 2025 adventures, this
+              guide begins with uncovering travel experiences that truly stand
+              out.
+            </p>
+          </div>
+
+          <div class="card">
+            <a
+              aria-label="black and gray camera on open map"
+              href="/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html"
+            >
+              <picture>
+                <img
+                  src="https://images.unsplash.com/photo-1503220954697-e02095e8e0d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUzNjE3MzIxfDA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
+                  srcset="https://images.unsplash.com/photo-1503220954697-e02095e8e0d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUzNjE3MzIxfDA&ixlib=rb-4.1.0&q=80&w=1080?w=200 200w, https://images.unsplash.com/photo-1503220954697-e02095e8e0d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUzNjE3MzIxfDA&ixlib=rb-4.1.0&q=80&w=1080?w=200&dpr=2 400w"
+                  sizes="(min-width:76rem) 18rem, 100vw"
+                  alt="black and gray camera on open map"
+                  loading="lazy"
+                  decoding="async"
+                  width="200"
+                  height="75"
+                />
+              </picture>
+            </a>
+            <h3>
+              <a href="/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html"
+                >Mastering Travel Flexibility: Tips and Inspiring Stories for
+                Adventurous Journeys</a
+              >
+            </h3>
+            <div id="published">
+              Published:
+              <em
+                ><time itemprop="datePublished" datetime="2025-07-27"
+                  >July 27, 2025</time
+                ></em
+              >
+            </div>
+            <p>
+              Mastering travel flexibility unlocks thrilling adventures and
+              opens the door to unforgettable experiences. Let’s dive into
+              embracing unpredictability and start with how flexibility fuels
+              adventurous journeys.
+            </p>
+          </div>
+
+          <div class="card">
+            <a
+              aria-label="a mountain range with trees in the foreground and a cloudy sky in the background"
+              href="/articles/unforgettable-travel-adventures-inspiring-journeys-world.html"
+            >
+              <picture>
+                <img
+                  src="https://images.unsplash.com/photo-1634864221446-d7f305974814?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwbW91bnRhaW4lMjBsYW5kc2NhcGVzfGVufDB8MHx8fDE3NTM2MTc4Nzh8MA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
+                  srcset="https://images.unsplash.com/photo-1634864221446-d7f305974814?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwbW91bnRhaW4lMjBsYW5kc2NhcGVzfGVufDB8MHx8fDE3NTM2MTc4Nzh8MA&ixlib=rb-4.1.0&q=80&w=1080?w=200 200w, https://images.unsplash.com/photo-1634864221446-d7f305974814?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwbW91bnRhaW4lMjBsYW5kc2NhcGVzfGVufDB8MHx8fDE3NTM2MTc4Nzh8MA&ixlib=rb-4.1.0&q=80&w=1080?w=200&dpr=2 400w"
+                  sizes="(min-width:76rem) 18rem, 100vw"
+                  alt="a mountain range with trees in the foreground and a cloudy sky in the background"
+                  loading="lazy"
+                  decoding="async"
+                  width="200"
+                  height="75"
+                />
+              </picture>
+            </a>
+            <h3>
+              <a href="/articles/unforgettable-travel-adventures-inspiring-journeys-world.html"
+                >Unforgettable Travel Adventures and Inspiring Journeys Around the
+                World</a
+              >
+            </h3>
+            <div id="published">
+              Published:
+              <em
+                ><time itemprop="datePublished" datetime="2025-07-27"
+                  >July 27, 2025</time
+                ></em
+              >
+            </div>
+            <p>
+              Embark on a journey to explore unforgettable travel adventures and
+              inspiring stories from around the world that ignite your
+              wanderlust. From top destinations to empowering solo trips, this
+              guide opens the door to experiences that will transform how you
+              travel.
+            </p>
+          </div>
+
+          <div class="card">
+            <a
+              aria-label="people gathering near the hut lot during daytime"
+              href="/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html"
+            >
+              <picture>
+                <img
+                  src="https://images.unsplash.com/photo-1560643248-d9c6124b2a44?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3aW5kaW5nJTIwbW91bnRhaW4lMjByb2FkcyUyMHJlbW90ZSUyMHZpbGxhZ2UlMjBjdWx0dXJhbCUyMGZlc3RpdmFsfGVufDB8MHx8fDE3NTMxOTAwNzR8MA&ixlib=rb-4.1.0&q=80&w=1080?w=200"
+                  srcset="https://images.unsplash.com/photo-1560643248-d9c6124b2a44?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3aW5kaW5nJTIwbW91bnRhaW4lMjByb2FkcyUyMHJlbW90ZSUyMHZpbGxhZ2UlMjBjdWx0dXJhbCUyMGZlc3RpdmFsfGVufDB8MHx8fDE3NTMxOTAwNzR8MA&ixlib=rb-4.1.0&q=80&w=1080?w=200 200w, https://images.unsplash.com/photo-1560643248-d9c6124b2a44?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3aW5kaW5nJTIwbW91bnRhaW4lMjByb2FkcyUyMHJlbW90ZSUyMHZpbGxhZ2UlMjBjdWx0dXJhbCUyMGZlc3RpdmFsfGVufDB8MHx8fDE3NTMxOTAwNzR8MA&ixlib=rb-4.1.0&q=80&w=1080?w=200&dpr=2 400w"
+                  sizes="(min-width:76rem) 18rem, 100vw"
+                  alt="people gathering near the hut lot during daytime"
+                  loading="lazy"
+                  decoding="async"
+                  width="200"
+                  height="75"
+                />
+              </picture>
+            </a>
+            <h3>
+              <a href="/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html"
+                >Navigating Global Travel: Unique Destinations, Challenges, and
+                Cultural Insights</a
+              >
+            </h3>
+            <div id="published">
+              Published:
+              <em
+                ><time itemprop="datePublished" datetime="2025-07-22"
+                  >July 22, 2025</time
+                ></em
+              >
+            </div>
+            <p>
+              Global travel invites explorers to venture beyond typical tourist
+              spots, uncovering unique destinations rich in culture and
+              challenge. This journey begins by exploring off-the-beaten-path
+              locations that reveal authentic experiences and set the stage for
+              meaningful adventures.
+            </p>
+          </div>
+
+          <div class="card">
+            <a
+              aria-label="a traffic light on a pole with a sky background"
+              href="/articles/navigating-modern-travel-safety-tips-destinations-experiences.html"
+            >
+              <picture>
+                <img
+                  src="https://images.unsplash.com/photo-1718242869012-34c2587f50aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHl8ZW58MHwwfHx8MTc1MjA3OTU0Mnww&ixlib=rb-4.1.0&q=80&w=1080?w=200"
+                  srcset="https://images.unsplash.com/photo-1718242869012-34c2587f50aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHl8ZW58MHwwfHx8MTc1MjA3OTU0Mnww&ixlib=rb-4.1.0&q=80&w=1080?w=200 200w, https://images.unsplash.com/photo-1718242869012-34c2587f50aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHl8ZW58MHwwfHx8MTc1MjA3OTU0Mnww&ixlib=rb-4.1.0&q=80&w=1080?w=200&dpr=2 400w"
+                  sizes="(min-width:76rem) 18rem, 100vw"
+                  alt="a traffic light on a pole with a sky background"
+                  loading="lazy"
+                  decoding="async"
+                  width="200"
+                  height="75"
+                />
+              </picture>
+            </a>
+            <h3>
+              <a href="/articles/navigating-modern-travel-safety-tips-destinations-experiences.html"
+                >Navigating Modern Travel: Safety Tips, Destinations, and
+                Experiences</a
+              >
+            </h3>
+            <div id="published">
+              Published:
+              <em
+                ><time itemprop="datePublished" datetime="2025-07-09"
+                  >July 9, 2025</time
+                ></em
+              >
+            </div>
+            <p>
+              Navigating modern travel requires a balance of excitement and
+              caution as new challenges and opportunities arise. This guide will
+              equip you with essential safety tips and practical advice to handle
+              disruptions, empowering you to explore top destinations with
+              confidence.
+            </p>
+          </div>
+        </div>
       </section>
     </main>
 


### PR DESCRIPTION
## Summary
- Insert seven static article cards into the homepage "Latest Articles" grid
- Remove unused JS loader and style grid for three columns on wide screens

## Testing
- `node --check assets/scripts/index.mjs`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b06fe5f49c8329930174822a99072e