### PR TITLE
Improve search result image quality

### DIFF
--- a/assets/scripts/search.mjs
+++ b/assets/scripts/search.mjs
@@ -1,1 +1,83 @@
-const loading=document.getElementById("loading"),searchInput=document.getElementById("search");function debounce(e,n=300){let t;return(...a)=>{clearTimeout(t),t=setTimeout(()=>e(...a),n)}}function renderPosts(e){const n=document.getElementById("results");n.innerHTML="",e.forEach(e=>{const t=new Date(e.publishDate).toLocaleDateString("en-US",{year:"numeric",month:"long",day:"numeric"}),a=document.createElement("div");a.className="card",a.innerHTML=`\n    <a\n        aria-label="${e.imageAlt}"\n        href="${e.url}">\n        <picture>\n            <img\n                src="${e.imageUrl}"\n                srcset="\n                ${e.imageUrl}&dpr=2 2x,\n                ${e.imageUrl} 1x\n                "\n                sizes="(min-width:38rem) 38rem, 100vw"\n                alt="${e.imageAlt}"\n                loading="lazy"\n                decoding="async"\n                width="1080"\n                height="385"\n            />\n        </picture>\n    </a>\n\n    <h3><a href="${e.url}">${e.title}</a></h3>\n\n     <div id="published">\n        Published:\n        <em\n        ><time itemprop="datePublished" datetime="${e.publishDate}">\n            ${t}</time\n        ></em\n        >\n    </div>\n\n  <p>${e.description}</p>\n`,n.appendChild(a)}),loading.style.display="none"}function setupSearch(e){const n=new Fuse(e,{keys:["title","description","publishDate"]}),t=debounce(t=>{loading.style.display="initial";const a=t.target.value.trim();renderPosts(a?n.search(a).map(e=>e.item):e)});searchInput.addEventListener("input",t)}!async function(){const e=await fetch("assets/search.json"),n=await e.json();renderPosts(n),setupSearch(n);const t=new URLSearchParams(window.location.search).get("query")||"";searchInput.value=t,t&&searchInput.dispatchEvent(new Event("input")),search.disabled=!1}();
+const loading = document.getElementById("loading");
+const searchInput = document.getElementById("search");
+
+function debounce(fn, delay = 300) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), delay);
+  };
+}
+
+function renderPosts(posts) {
+  const results = document.getElementById("results");
+  results.innerHTML = "";
+  posts.forEach((post) => {
+    const published = new Date(post.publishDate).toLocaleDateString(
+      "en-US",
+      { year: "numeric", month: "long", day: "numeric" }
+    );
+    const card = document.createElement("div");
+    card.className = "card";
+    const imageUrl = post.imageUrl
+      .replace(/w=\d+/g, "w=1300")
+      .replace(/h=\d+/g, "h=500");
+    card.innerHTML = `
+    <a
+        aria-label="${post.imageAlt}"
+        href="${post.url}">
+        <picture>
+            <img
+                src="${imageUrl}"
+                srcset="
+                ${imageUrl}&dpr=2 2x,
+                ${imageUrl} 1x
+                "
+                sizes="(min-width:38rem) 38rem, 100vw"
+                alt="${post.imageAlt}"
+                loading="lazy"
+                decoding="async"
+                width="1300"
+                height="500"
+            />
+        </picture>
+    </a>
+
+    <h3><a href="${post.url}">${post.title}</a></h3>
+
+     <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="${post.publishDate}">
+            ${published}</time>
+        </em>
+    </div>
+
+  <p>${post.description}</p>
+    `;
+    results.appendChild(card);
+  });
+  loading.style.display = "none";
+}
+
+function setupSearch(posts) {
+  const fuse = new Fuse(posts, {
+    keys: ["title", "description", "publishDate"],
+  });
+  const handler = debounce((evt) => {
+    loading.style.display = "initial";
+    const query = evt.target.value.trim();
+    renderPosts(query ? fuse.search(query).map((r) => r.item) : posts);
+  });
+  searchInput.addEventListener("input", handler);
+}
+
+(async function () {
+  const response = await fetch("assets/search.json");
+  const posts = await response.json();
+  renderPosts(posts);
+  setupSearch(posts);
+  const query = new URLSearchParams(window.location.search).get("query") || "";
+  searchInput.value = query;
+  if (query) searchInput.dispatchEvent(new Event("input"));
+  searchInput.disabled = false;
+})();

--- a/assets/styles/search.css
+++ b/assets/styles/search.css
@@ -1,1 +1,1 @@
-search{width:100%}#results{display:flex;flex-direction:column;gap:2rem}img,picture{max-height:20rem}
+search{width:100%}#results{display:flex;flex-direction:column;gap:2rem}img,picture{max-height:20rem}.card{background-color:#fff}


### PR DESCRIPTION
## Summary
- Increase Unsplash image requests to 1300px wide and adjust rendering to use the higher resolution images
- Set search result cards to use a white background for better contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1aa6db8648329b81f9a3721a5e164