### PR TITLE
Move Unsplash credits to image title

### DIFF
--- a/articles/african-safari-experience-a-journey-into-the-wild.html
+++ b/articles/african-safari-experience-a-journey-into-the-wild.html
@@ -239,7 +239,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/selective-focus-photography-of-giraffe-A-p2uJsN4i4" />
           </picture>
 
           <figcaption class="image-description">
@@ -251,12 +251,7 @@
               >anthony_melone</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/selective-focus-photography-of-giraffe-A-p2uJsN4i4"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/architectural-marvels-modern-wonders-world.html
+++ b/articles/architectural-marvels-modern-wonders-world.html
@@ -245,7 +245,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/white-concrete-building-during-daytime-ACt8ycSzpdE" />
           </picture>
 
           <figcaption class="image-description">
@@ -257,12 +257,7 @@
               >photohunter</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/white-concrete-building-during-daytime-ACt8ycSzpdE"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/behind-scenes-worlds-largest-festivals.html
+++ b/articles/behind-scenes-worlds-largest-festivals.html
@@ -245,7 +245,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/white-ceramic-dinnerware-set-aEnH4hJ_Mrs" />
           </picture>
 
           <figcaption class="image-description">
@@ -254,12 +254,7 @@
               >chuttersnap</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/white-ceramic-dinnerware-set-aEnH4hJ_Mrs"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/best-safari-destinations.html
+++ b/articles/best-safari-destinations.html
@@ -246,7 +246,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/adult-gray-elephant-stands-near-gray-bush-DD4B0dEDzNY" />
           </picture>
 
           <figcaption class="image-description">
@@ -258,12 +258,7 @@
               >shotbythegypsy</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/adult-gray-elephant-stands-near-gray-bush-DD4B0dEDzNY"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/best-travel-apps.html
+++ b/articles/best-travel-apps.html
@@ -232,7 +232,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/person-holding-silver-iphone-6-HGLCvGWujGE" />
           </picture>
 
           <figcaption class="image-description">
@@ -241,12 +241,7 @@
               >fikrirasyid</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/person-holding-silver-iphone-6-HGLCvGWujGE"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/beyond-hostels-hotels-unique-accommodations-adventurous-traveler.html
+++ b/articles/beyond-hostels-hotels-unique-accommodations-adventurous-traveler.html
@@ -243,7 +243,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/a-yellow-and-white-train-pulling-into-a-train-station-LHSBXKfSkdw" />
           </picture>
 
           <figcaption class="image-description">
@@ -252,12 +252,7 @@
               >omegamezle</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-yellow-and-white-train-pulling-into-a-train-station-LHSBXKfSkdw"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/chasing-northern-lights-best-places.html
+++ b/articles/chasing-northern-lights-best-places.html
@@ -263,7 +263,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/aerial-photography-of-flowers-at-daytime-TRhGEGdw-YY" />
           </picture>
 
           <figcaption class="image-description">
@@ -275,12 +275,7 @@
               >joelholland</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/aerial-photography-of-flowers-at-daytime-TRhGEGdw-YY"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/culinary-trails-origins-iconic-street-food.html
+++ b/articles/culinary-trails-origins-iconic-street-food.html
@@ -261,7 +261,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/pesto-pasta-with-sliced-tomatoes-served-on-white-ceramic-plate-12eHC6FxPyg" />
           </picture>
 
           <figcaption class="image-description">
@@ -273,12 +273,7 @@
               >eaterscollective</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/pesto-pasta-with-sliced-tomatoes-served-on-white-ceramic-plate-12eHC6FxPyg"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/cultural-immersion-experiences.html
+++ b/articles/cultural-immersion-experiences.html
@@ -236,7 +236,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/woman-in-purple-and-yellow-floral-dress-ABsiZOCW2L0" />
           </picture>
 
           <figcaption class="image-description">
@@ -245,12 +245,7 @@
               >sonika_agarwal</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/woman-in-purple-and-yellow-floral-dress-ABsiZOCW2L0"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/dark-tourism-worlds-haunting-locations.html
+++ b/articles/dark-tourism-worlds-haunting-locations.html
@@ -241,7 +241,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/grayscale-photography-of-man-standing-near-studio-camera-and-woman-sitting-while-holding-book-R7G3kcwuiY4" />
           </picture>
 
           <figcaption class="image-description">
@@ -253,12 +253,7 @@
               >austriannationallibrary</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/grayscale-photography-of-man-standing-near-studio-camera-and-woman-sitting-while-holding-book-R7G3kcwuiY4"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/digital-nomad-life-world.html
+++ b/articles/digital-nomad-life-world.html
@@ -244,7 +244,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/person-holding-blue-and-brown-map-CIuakYIjadc" />
           </picture>
 
           <figcaption class="image-description">
@@ -256,12 +256,7 @@
               >julensan09</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/person-holding-blue-and-brown-map-CIuakYIjadc"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/discover-transformative-travel-stories-trending-destinations.html
+++ b/articles/discover-transformative-travel-stories-trending-destinations.html
@@ -249,7 +249,7 @@
               decoding="async"
               width="4770"
               height="3180"
-            />
+             title="https://unsplash.com/photos/the-word-travel-spelled-with-scrabbles-on-a-wooden-table-rG4a6ZfyHBw" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -260,12 +260,7 @@
               >Ling App</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/the-word-travel-spelled-with-scrabbles-on-a-wooden-table-rG4a6ZfyHBw"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/discovering-underwater-world-best-snorkeling-spots-globally.html
+++ b/articles/discovering-underwater-world-best-snorkeling-spots-globally.html
@@ -227,7 +227,7 @@
             https://images.unsplash.com/photo-1530053969600-caed2596d242?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBjb3JhbCUyMHJlZWYlMjBzbm9ya2VsaW5nJTIwdW5kZXJ3YXRlcnxlbnwwfHx8fDE3NDUyNDEwMzF8MA&ixlib=rb-4.0.3&q=80&w=200h"
             sizes="(max-width: 600px) 100vw" alt="clear blue body of water"
             decoding="async" width="1080" height="400" fetchpriority="high"
-            style="display:block; width:100%; height:auto;" />
+            style="display:block; width:100%; height:auto;"  title="https://unsplash.com/photos/clear-blue-body-of-water-XexawgzYOBc" />
           </picture>
 
           <figcaption class="image-description">
@@ -239,12 +239,7 @@
               >cristianpalmer</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/clear-blue-body-of-water-XexawgzYOBc"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/eco-friendly-traveling-world-sustainably.html
+++ b/articles/eco-friendly-traveling-world-sustainably.html
@@ -250,7 +250,7 @@
               decoding="async"
               width="1080"
               height="400"
-            />
+             title="https://unsplash.com/photos/person-holding-black-and-brown-globe-ball-while-standing-on-grass-land-golden-hour-photography-gEKMstKfZ6w" />
           </picture>
 
           <figcaption class="image-description">
@@ -262,12 +262,7 @@
               >benwhitephotography</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/person-holding-black-and-brown-globe-ball-while-standing-on-grass-land-golden-hour-photography-gEKMstKfZ6w"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/embracing-eco-tourism-sustainable-journey-costa-rica.html
+++ b/articles/embracing-eco-tourism-sustainable-journey-costa-rica.html
@@ -237,7 +237,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/body-of-water-under-cloudy-sky-HS73XTjaUsA" />
           </picture>
 
           <figcaption class="image-description">
@@ -249,12 +249,7 @@
               >pablorobles</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/body-of-water-under-cloudy-sky-HS73XTjaUsA"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/explore-enchanting-destinations-smart-travel-planning-2025.html
+++ b/articles/explore-enchanting-destinations-smart-travel-planning-2025.html
@@ -256,7 +256,7 @@
               decoding="async"
               width="4032"
               height="3024"
-            />
+             title="https://unsplash.com/photos/a-bus-driving-through-a-canyon-pVvSQXD9xPY" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -267,12 +267,7 @@
               >Allen Boguslavsky</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-bus-driving-through-a-canyon-pVvSQXD9xPY"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/explore-unique-travel-experiences-hidden-gems-2025.html
+++ b/articles/explore-unique-travel-experiences-hidden-gems-2025.html
@@ -248,7 +248,7 @@
               decoding="async"
               width="4032"
               height="3024"
-            />
+             title="https://unsplash.com/photos/black-nipa-huts-during-daytime-uRSk8pT0Elg" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -259,12 +259,7 @@
               >Marcella Oscar</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/black-nipa-huts-during-daytime-uRSk8pT0Elg"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/exploring-arctic-travel-guide.html
+++ b/articles/exploring-arctic-travel-guide.html
@@ -247,7 +247,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/body-of-water-surrounded-by-trees-NRQV-hBF10M" />
           </picture>
 
           <figcaption class="image-description">
@@ -256,12 +256,7 @@
               >baileyzindel</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/body-of-water-surrounded-by-trees-NRQV-hBF10M"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/exploring-authentic-travel-experiences-hidden-gems-challenges.html
+++ b/articles/exploring-authentic-travel-experiences-hidden-gems-challenges.html
@@ -241,7 +241,7 @@
               decoding="async"
               width="4032"
               height="3024"
-            />
+             title="https://unsplash.com/photos/a-group-of-people-standing-around-a-market-byV6av5rpqk" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -252,12 +252,7 @@
               >Estefania Rainie</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-group-of-people-standing-around-a-market-byV6av5rpqk"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/exploring-emerging-travel-trends-and-unique-hobby-inspirations.html
+++ b/articles/exploring-emerging-travel-trends-and-unique-hobby-inspirations.html
@@ -234,7 +234,7 @@
               decoding="async"
               width="4898"
               height="3265"
-            />
+             title="https://unsplash.com/photos/airplanes-on-the-runway-_M18XbHJwtc" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -245,12 +245,7 @@
               >Brice Cooper</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/airplanes-on-the-runway-_M18XbHJwtc"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/exploring-emerging-travel-trends-unique-hobby-inspirations.html
+++ b/articles/exploring-emerging-travel-trends-unique-hobby-inspirations.html
@@ -232,7 +232,7 @@
               decoding="async"
               width="6000"
               height="4000"
-            />
+             title="https://unsplash.com/photos/a-group-of-people-in-canoes-in-a-river-onTVvIN7sfE" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -243,12 +243,7 @@
               >Nicolas Houdayer</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-group-of-people-in-canoes-in-a-river-onTVvIN7sfE"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/exploring-new-horizons-top-travel-tips-destinations-2025.html
+++ b/articles/exploring-new-horizons-top-travel-tips-destinations-2025.html
@@ -251,7 +251,7 @@
               decoding="async"
               width="7952"
               height="5304"
-            />
+             title="https://unsplash.com/photos/xUFQ8iKcY-o" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -262,12 +262,7 @@
               >JOHN TOWNER</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/xUFQ8iKcY-o"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/exploring-scottish-highlands.html
+++ b/articles/exploring-scottish-highlands.html
@@ -243,7 +243,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/white-and-brown-concrete-building-on-green-grass-field-s0_B1to21_k" />
           </picture>
 
           <figcaption class="image-description">
@@ -255,12 +255,7 @@
               >garyellisphoto</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/white-and-brown-concrete-building-on-green-grass-field-s0_B1to21_k"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/exploring-trending-travel-destinations-and-relaxing-hobby-ideas.html
+++ b/articles/exploring-trending-travel-destinations-and-relaxing-hobby-ideas.html
@@ -230,7 +230,7 @@
               decoding="async"
               width="6196"
               height="3485"
-            />
+             title="https://unsplash.com/photos/the-sun-is-setting-over-the-ocean-with-a-palm-tree-in-the-foreground-Z6dFMmCHoyc" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -241,12 +241,7 @@
               >Harry Gillen</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/the-sun-is-setting-over-the-ocean-with-a-palm-tree-in-the-foreground-Z6dFMmCHoyc"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/exploring-unesco-sites.html
+++ b/articles/exploring-unesco-sites.html
@@ -265,7 +265,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/grayscale-photo-of-low-angle-view-of-building-K67sBVqLLuw" />
           </picture>
 
           <figcaption class="image-description">
@@ -277,12 +277,7 @@
               >joakimnadell</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/grayscale-photo-of-low-angle-view-of-building-K67sBVqLLuw"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/exploring-unique-destinations-travel-experiences-2025.html
+++ b/articles/exploring-unique-destinations-travel-experiences-2025.html
@@ -247,7 +247,7 @@
               decoding="async"
               width="6016"
               height="4000"
-            />
+             title="https://unsplash.com/photos/brown-house-on-mountain-eo6P9GxzMYo" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -258,12 +258,7 @@
               >Yousef Espanioly</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/brown-house-on-mountain-eo6P9GxzMYo"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/exploring-untouched-forests.html
+++ b/articles/exploring-untouched-forests.html
@@ -242,7 +242,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/man-taking-photo-of-hot-air-balloons-eOcyhe5-9sQ" />
           </picture>
 
           <figcaption class="image-description">
@@ -254,12 +254,7 @@
               >directormesut</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/man-taking-photo-of-hot-air-balloons-eOcyhe5-9sQ"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/exploring-worlds-historical-walking-routes.html
+++ b/articles/exploring-worlds-historical-walking-routes.html
@@ -260,7 +260,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/grayscale-photo-of-low-angle-view-of-building-K67sBVqLLuw" />
           </picture>
 
           <figcaption class="image-description">
@@ -272,12 +272,7 @@
               >joakimnadell</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/grayscale-photo-of-low-angle-view-of-building-K67sBVqLLuw"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/exploring-worlds-most-religious-sites.html
+++ b/articles/exploring-worlds-most-religious-sites.html
@@ -244,7 +244,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/topless-man-wearing-black-beaded-necklace-and-blue-denim-shorts-standing-on-rocky-shore-during-daytime-I8Q261NtB24" />
           </picture>
 
           <figcaption class="image-description">
@@ -253,12 +253,7 @@
               >dariusbashar</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/topless-man-wearing-black-beaded-necklace-and-blue-denim-shorts-standing-on-rocky-shore-during-daytime-I8Q261NtB24"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/glamping-world-luxury-tents-incredible-views.html
+++ b/articles/glamping-world-luxury-tents-incredible-views.html
@@ -245,7 +245,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/trees-on-forest-with-sun-rays-sp-p7uuT0tw" />
           </picture>
 
           <figcaption class="image-description">
@@ -257,12 +257,7 @@
               >sebastian_unrau</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/trees-on-forest-with-sun-rays-sp-p7uuT0tw"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/global-gastronomy-tasting-traditional-dishes-different-cultures.html
+++ b/articles/global-gastronomy-tasting-traditional-dishes-different-cultures.html
@@ -263,7 +263,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/pesto-pasta-with-sliced-tomatoes-served-on-white-ceramic-plate-12eHC6FxPyg" />
           </picture>
 
           <figcaption class="image-description">
@@ -275,12 +275,7 @@
               >eaterscollective</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/pesto-pasta-with-sliced-tomatoes-served-on-white-ceramic-plate-12eHC6FxPyg"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/going-green-vegan-vegetarian-travel.html
+++ b/articles/going-green-vegan-vegetarian-travel.html
@@ -245,7 +245,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/flat-lay-photography-of-sliced-apples-sausages-chips-and-brown-sauce-C1fMH2Vej8A" />
           </picture>
 
           <figcaption class="image-description">
@@ -254,12 +254,7 @@
               >brookelark</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/flat-lay-photography-of-sliced-apples-sausages-chips-and-brown-sauce-C1fMH2Vej8A"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/hidden-gems-uncharted-travel-destinations.html
+++ b/articles/hidden-gems-uncharted-travel-destinations.html
@@ -240,7 +240,7 @@
               alt="airplane on sky during golden hour"
               width="760"
               height="400"
-            />
+             title="https://unsplash.com/photos/airplane-on-sky-during-golden-hour-M0AWNxnLaMw" />
           </picture>
 
           <figcaption class="image-description">
@@ -252,12 +252,7 @@
               >wistomsin</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/airplane-on-sky-during-golden-hour-M0AWNxnLaMw"
-              rel="nofollow"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/historic-railways-world-journey.html
+++ b/articles/historic-railways-world-journey.html
@@ -242,7 +242,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/a-shack-sitting-on-top-of-a-rocky-hillside-EXhGZMVIsmA" />
           </picture>
 
           <figcaption class="image-description">
@@ -254,12 +254,7 @@
               >jcorl</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-shack-sitting-on-top-of-a-rocky-hillside-EXhGZMVIsmA"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/inspiring-travel-destinations-tips-2025-adventures.html
+++ b/articles/inspiring-travel-destinations-tips-2025-adventures.html
@@ -247,7 +247,7 @@
               decoding="async"
               width="3264"
               height="2448"
-            />
+             title="https://unsplash.com/photos/a-group-of-people-standing-around-a-body-of-water-EwP1eDEFKEA" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -258,12 +258,7 @@
               >Gaurav Patil</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-group-of-people-standing-around-a-body-of-water-EwP1eDEFKEA"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/navigating-complexities-of-travel-tips-tales-realities.html
+++ b/articles/navigating-complexities-of-travel-tips-tales-realities.html
@@ -239,7 +239,7 @@
               decoding="async"
               width="6016"
               height="4016"
-            />
+             title="https://unsplash.com/photos/a-chandelier-hangs-under-a-majestic-domed-ceiling-UuSTFjqexHA" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -250,12 +250,7 @@
               >Kristina Tochilko</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-chandelier-hangs-under-a-majestic-domed-ceiling-UuSTFjqexHA"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html
+++ b/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html
@@ -255,7 +255,7 @@
               decoding="async"
               width="3264"
               height="2448"
-            />
+             title="https://unsplash.com/photos/people-gathering-near-the-hut-lot-during-daytime-mY1jFfp6x-s" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -266,12 +266,7 @@
               >Eddy Kristianto</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/people-gathering-near-the-hut-lot-during-daytime-mY1jFfp6x-s"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html
+++ b/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html
@@ -256,7 +256,7 @@
               decoding="async"
               width="4928"
               height="3264"
-            />
+             title="https://unsplash.com/photos/man-wearing-white-shirt-overlooking-on-white-clouds-KLTR8uHwrzM" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -267,12 +267,7 @@
               >Haidan</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/man-wearing-white-shirt-overlooking-on-white-clouds-KLTR8uHwrzM"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/navigating-modern-travel-insights-experiences-tips-2025.html
+++ b/articles/navigating-modern-travel-insights-experiences-tips-2025.html
@@ -231,7 +231,7 @@
               decoding="async"
               width="6000"
               height="4000"
-            />
+             title="https://unsplash.com/photos/people-inside-changi-airport-singapore-MuGckyvIu14" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -242,12 +242,7 @@
               >Abdurrahman</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/people-inside-changi-airport-singapore-MuGckyvIu14"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html
+++ b/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html
@@ -250,7 +250,7 @@
               decoding="async"
               width="6000"
               height="2777"
-            />
+             title="https://unsplash.com/photos/a-group-of-people-walking-down-a-hallway-6ofHVIQ30VY" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -261,12 +261,7 @@
               >BREAKIFY</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-group-of-people-walking-down-a-hallway-6ofHVIQ30VY"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/navigating-modern-travel-safety-tips-destinations-experiences.html
+++ b/articles/navigating-modern-travel-safety-tips-destinations-experiences.html
@@ -249,7 +249,7 @@
               decoding="async"
               width="6000"
               height="4000"
-            />
+             title="https://unsplash.com/photos/a-traffic-light-on-a-pole-with-a-sky-background-_rsZfVjqRaE" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -260,12 +260,7 @@
               >Qihang Fan</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-traffic-light-on-a-pole-with-a-sky-background-_rsZfVjqRaE"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/navigating-night-markets-food-lovers-guide.html
+++ b/articles/navigating-night-markets-food-lovers-guide.html
@@ -261,7 +261,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/pesto-pasta-with-sliced-tomatoes-served-on-white-ceramic-plate-12eHC6FxPyg" />
           </picture>
 
           <figcaption class="image-description">
@@ -273,12 +273,7 @@
               >eaterscollective</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/pesto-pasta-with-sliced-tomatoes-served-on-white-ceramic-plate-12eHC6FxPyg"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/navigating-realities-wonders-modern-travel-2025.html
+++ b/articles/navigating-realities-wonders-modern-travel-2025.html
@@ -250,7 +250,7 @@
               decoding="async"
               width="7070"
               height="4713"
-            />
+             title="https://unsplash.com/photos/a-long-hallway-in-a-building-with-lights-on-ROTbXwir7cU" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -261,12 +261,7 @@
               >Dennis Zhang</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-long-hallway-in-a-building-with-lights-on-ROTbXwir7cU"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/navigating-solo-journeys-travel-challenges-2025.html
+++ b/articles/navigating-solo-journeys-travel-challenges-2025.html
@@ -250,7 +250,7 @@
               decoding="async"
               width="4926"
               height="3274"
-            />
+             title="https://unsplash.com/photos/person-carrying-yellow-and-black-backpack-walking-between-green-plants-UVyOfX3v0Ls" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -261,12 +261,7 @@
               >Holly Mandarich</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/person-carrying-yellow-and-black-backpack-walking-between-green-plants-UVyOfX3v0Ls"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html
+++ b/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html
@@ -249,7 +249,7 @@
               decoding="async"
               width="5312"
               height="2988"
-            />
+             title="https://unsplash.com/photos/a-car-driving-down-a-dirt-road-in-the-mountains-QKTAn73PDFs" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -260,12 +260,7 @@
               >Christopher Laberinto</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-car-driving-down-a-dirt-road-in-the-mountains-QKTAn73PDFs"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/pedal-paradises-destinations-cycling-enthusiasts.html
+++ b/articles/pedal-paradises-destinations-cycling-enthusiasts.html
@@ -262,7 +262,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/forest-heat-by-sunbeam-RwHv7LgeC7s" />
           </picture>
 
           <figcaption class="image-description">
@@ -271,12 +271,7 @@
               >jplenio</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/forest-heat-by-sunbeam-RwHv7LgeC7s"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/river-cruises-europe.html
+++ b/articles/river-cruises-europe.html
@@ -241,7 +241,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/aerial-photography-of-flowers-at-daytime-TRhGEGdw-YY" />
           </picture>
 
           <figcaption class="image-description">
@@ -253,12 +253,7 @@
               >joelholland</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/aerial-photography-of-flowers-at-daytime-TRhGEGdw-YY"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/roaming-roof-world-himalayas-guide.html
+++ b/articles/roaming-roof-world-himalayas-guide.html
@@ -240,7 +240,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/a-view-of-a-valley-with-mountains-in-the-background-h4O1AQ1V8fo" />
           </picture>
 
           <figcaption class="image-description">
@@ -252,12 +252,7 @@
               >natureandmylens</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-view-of-a-valley-with-mountains-in-the-background-h4O1AQ1V8fo"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/sanctuaries-sky-worlds-picturesque-mountain-retreats.html
+++ b/articles/sanctuaries-sky-worlds-picturesque-mountain-retreats.html
@@ -245,7 +245,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/forest-heat-by-sunbeam-RwHv7LgeC7s" />
           </picture>
 
           <figcaption class="image-description">
@@ -254,12 +254,7 @@
               >jplenio</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/forest-heat-by-sunbeam-RwHv7LgeC7s"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/solo-travel-guide-southeast-asia-safety.html
+++ b/articles/solo-travel-guide-southeast-asia-safety.html
@@ -236,7 +236,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/brown-and-gold-pagoda-near-cherry-blossom-cddaZDt6uRw" />
           </picture>
 
           <figcaption class="image-description">
@@ -248,12 +248,7 @@
               >yukato</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/brown-and-gold-pagoda-near-cherry-blossom-cddaZDt6uRw"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/solo-travel-safety-guide.html
+++ b/articles/solo-travel-safety-guide.html
@@ -245,7 +245,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/airplane-on-sky-during-golden-hour-M0AWNxnLaMw" />
           </picture>
 
           <figcaption class="image-description">
@@ -257,12 +257,7 @@
               >wistomsin</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/airplane-on-sky-during-golden-hour-M0AWNxnLaMw"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/sustainable-food-explorations.html
+++ b/articles/sustainable-food-explorations.html
@@ -260,7 +260,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/pesto-pasta-with-sliced-tomatoes-served-on-white-ceramic-plate-12eHC6FxPyg" />
           </picture>
 
           <figcaption class="image-description">
@@ -272,12 +272,7 @@
               >eaterscollective</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/pesto-pasta-with-sliced-tomatoes-served-on-white-ceramic-plate-12eHC6FxPyg"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/timeless-timelines-history-iconic-landmarks.html
+++ b/articles/timeless-timelines-history-iconic-landmarks.html
@@ -243,7 +243,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/grayscale-photo-of-low-angle-view-of-building-K67sBVqLLuw" />
           </picture>
 
           <figcaption class="image-description">
@@ -255,12 +255,7 @@
               >joakimnadell</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/grayscale-photo-of-low-angle-view-of-building-K67sBVqLLuw"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/top-10-hidden-gems-europe.html
+++ b/articles/top-10-hidden-gems-europe.html
@@ -250,7 +250,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/photo-of-two-mountains-lpjb_UMOyx8" />
           </picture>
 
           <figcaption class="image-description">
@@ -259,12 +259,7 @@
               >danielroe</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/photo-of-two-mountains-lpjb_UMOyx8"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/top-surfing-destinations-world.html
+++ b/articles/top-surfing-destinations-world.html
@@ -237,7 +237,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/aerial-photography-of-seashore-F6XKjhMNB14" />
           </picture>
 
           <figcaption class="image-description">
@@ -249,12 +249,7 @@
               >lifeofmikey</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/aerial-photography-of-seashore-F6XKjhMNB14"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/touring-tropics-comprehensive-guide.html
+++ b/articles/touring-tropics-comprehensive-guide.html
@@ -244,7 +244,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/palm-trees-u-vmeJcJ-Z4" />
           </picture>
 
           <figcaption class="image-description">
@@ -253,12 +253,7 @@
               >chuttersnap</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/palm-trees-u-vmeJcJ-Z4"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/transcontinental-trails-world.html
+++ b/articles/transcontinental-trails-world.html
@@ -244,7 +244,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/a-trail-winds-through-a-grassy-area-with-mountains-in-the-background-RZRwQg3aUOg" />
           </picture>
 
           <figcaption class="image-description">
@@ -256,12 +256,7 @@
               >afcurtis</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-trail-winds-through-a-grassy-area-with-mountains-in-the-background-RZRwQg3aUOg"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/travel-budget-tips.html
+++ b/articles/travel-budget-tips.html
@@ -248,7 +248,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/airplane-on-sky-during-golden-hour-M0AWNxnLaMw" />
           </picture>
 
           <figcaption class="image-description">
@@ -260,12 +260,7 @@
               >wistomsin</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/airplane-on-sky-during-golden-hour-M0AWNxnLaMw"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html
+++ b/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html
@@ -255,7 +255,7 @@
               decoding="async"
               width="5827"
               height="3885"
-            />
+             title="https://unsplash.com/photos/black-and-gray-camera-on-open-map-yRf7ABVDddM" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -266,12 +266,7 @@
               >Chris Lawton</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/black-and-gray-camera-on-open-map-yRf7ABVDddM"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/travel-hacks-tips-save-money-time.html
+++ b/articles/travel-hacks-tips-save-money-time.html
@@ -236,7 +236,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/person-holding-ballpoint-pen-writing-on-notebook-505eectW54k" />
           </picture>
 
           <figcaption class="image-description">
@@ -248,12 +248,7 @@
               >thoughtcatalog</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/person-holding-ballpoint-pen-writing-on-notebook-505eectW54k"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/traveling-silk-road.html
+++ b/articles/traveling-silk-road.html
@@ -243,7 +243,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/turned-off-black-television-UBhpOIHnazM" />
           </picture>
 
           <figcaption class="image-description">
@@ -255,12 +255,7 @@
               >ajeetmestry</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/turned-off-black-television-UBhpOIHnazM"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/traveling-through-taste-culinary-journey.html
+++ b/articles/traveling-through-taste-culinary-journey.html
@@ -245,7 +245,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/pesto-pasta-with-sliced-tomatoes-served-on-white-ceramic-plate-12eHC6FxPyg" />
           </picture>
 
           <figcaption class="image-description">
@@ -257,12 +257,7 @@
               >eaterscollective</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/pesto-pasta-with-sliced-tomatoes-served-on-white-ceramic-plate-12eHC6FxPyg"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/traveling-through-time-oldest-cities.html
+++ b/articles/traveling-through-time-oldest-cities.html
@@ -246,7 +246,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/cityscape-of-high-rise-building-during-golden-hour-bx1G9db3FjA" />
           </picture>
 
           <figcaption class="image-description">
@@ -258,12 +258,7 @@
               >devintavery</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/cityscape-of-high-rise-building-during-golden-hour-bx1G9db3FjA"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/traveling-twist-unique-festivals-globe.html
+++ b/articles/traveling-twist-unique-festivals-globe.html
@@ -227,7 +227,7 @@
               width="760"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/person-holding-black-and-brown-globe-ball-while-standing-on-grass-land-golden-hour-photography-gEKMstKfZ6w" />
           </picture>
 
           <figcaption class="image-description">
@@ -239,12 +239,7 @@
               >benwhitephotography</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/person-holding-black-and-brown-globe-ball-while-standing-on-grass-land-golden-hour-photography-gEKMstKfZ6w"
-              rel="nofollow"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/traveling-without-trace.html
+++ b/articles/traveling-without-trace.html
@@ -263,7 +263,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/photo-of-two-mountains-lpjb_UMOyx8" />
           </picture>
 
           <figcaption class="image-description">
@@ -272,12 +272,7 @@
               >danielroe</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/photo-of-two-mountains-lpjb_UMOyx8"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/ultimate-family-solo-travel-planning-tips-2025.html
+++ b/articles/ultimate-family-solo-travel-planning-tips-2025.html
@@ -241,7 +241,7 @@
               decoding="async"
               width="3999"
               height="2667"
-            />
+             title="https://unsplash.com/photos/a-family-bonding-activity-on-a-piece-of-paper-next-to-a-typewriter-SiYbEQrRv_I" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -252,12 +252,7 @@
               >Markus Winkler</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-family-bonding-activity-on-a-piece-of-paper-next-to-a-typewriter-SiYbEQrRv_I"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html
+++ b/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html
@@ -251,7 +251,7 @@
               decoding="async"
               width="6000"
               height="4000"
-            />
+             title="https://unsplash.com/photos/aerial-photography-of-body-of-water-during-daytime-kY-7tROuc7I" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -262,12 +262,7 @@
               >Artiom Vallat</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/aerial-photography-of-body-of-water-during-daytime-kY-7tROuc7I"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/unexpected-journeys-realities-modern-travel-experiences.html
+++ b/articles/unexpected-journeys-realities-modern-travel-experiences.html
@@ -251,7 +251,7 @@
               decoding="async"
               width="4928"
               height="3264"
-            />
+             title="https://unsplash.com/photos/man-wearing-white-shirt-overlooking-on-white-clouds-KLTR8uHwrzM" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -262,12 +262,7 @@
               >Haidan</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/man-wearing-white-shirt-overlooking-on-white-clouds-KLTR8uHwrzM"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html
+++ b/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html
@@ -249,7 +249,7 @@
               decoding="async"
               width="6000"
               height="4000"
-            />
+             title="https://unsplash.com/photos/a-large-brick-building-sitting-on-top-of-a-dry-grass-field-TZmc6k3xmzM" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -260,12 +260,7 @@
               >Brett Wharton</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-large-brick-building-sitting-on-top-of-a-dry-grass-field-TZmc6k3xmzM"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/unforgettable-travel-adventures-inspiring-journeys-world.html
+++ b/articles/unforgettable-travel-adventures-inspiring-journeys-world.html
@@ -254,7 +254,7 @@
               decoding="async"
               width="6000"
               height="4000"
-            />
+             title="https://unsplash.com/photos/a-mountain-range-with-trees-in-the-foreground-and-a-cloudy-sky-in-the-background-I7EgmLn1_oI" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -265,12 +265,7 @@
               >Jonathan Letniak</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-mountain-range-with-trees-in-the-foreground-and-a-cloudy-sky-in-the-background-I7EgmLn1_oI"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/unforgettable-travel-experiences-top-destinations-2025.html
+++ b/articles/unforgettable-travel-experiences-top-destinations-2025.html
@@ -244,7 +244,7 @@
               decoding="async"
               width="3872"
               height="2592"
-            />
+             title="https://unsplash.com/photos/photo-of-assorted-color-air-balloon-lot-in-mid-air-during-daytime-bBF9e2UUh88" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -255,12 +255,7 @@
               >Mar Cerdeira</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/photo-of-assorted-color-air-balloon-lot-in-mid-air-during-daytime-bBF9e2UUh88"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/unforgettable-travel-journeys-unique-destinations-experiences.html
+++ b/articles/unforgettable-travel-journeys-unique-destinations-experiences.html
@@ -256,7 +256,7 @@
               decoding="async"
               width="3936"
               height="2624"
-            />
+             title="https://unsplash.com/photos/green-trees-near-body-of-water-during-daytime-ldO5sRd36VE" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -267,12 +267,7 @@
               >Frames For Your Heart</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/green-trees-near-body-of-water-during-daytime-ldO5sRd36VE"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html
+++ b/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html
@@ -246,7 +246,7 @@
               decoding="async"
               width="4347"
               height="2898"
-            />
+             title="https://unsplash.com/photos/people-standing-on-brown-sand-under-blue-sky-during-daytime-fF2xZtbgOuE" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -257,12 +257,7 @@
               >Ken Cheung</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/people-standing-on-brown-sand-under-blue-sky-during-daytime-fF2xZtbgOuE"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
 

--- a/articles/unplanned-journeys-travel-realities-insights.html
+++ b/articles/unplanned-journeys-travel-realities-insights.html
@@ -252,7 +252,7 @@
               decoding="async"
               width="3454"
               height="2591"
-            />
+             title="https://unsplash.com/photos/a-man-pushing-a-cart-full-of-bags-down-a-street-MlHzt9tMvFg" />
           </picture>
           <figcaption class="image-description">
             Image by
@@ -263,12 +263,7 @@
               >Etienne Girardet</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/a-man-pushing-a-cart-full-of-bags-down-a-street-MlHzt9tMvFg"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section id="chapter-1">

--- a/articles/unplugged-adventures-travel-without-technology.html
+++ b/articles/unplugged-adventures-travel-without-technology.html
@@ -237,7 +237,7 @@
               width="1080"
               height="400"
               fetchpriority="high"
-            />
+             title="https://unsplash.com/photos/orange-flowers-IicyiaPYGGI" />
           </picture>
 
           <figcaption class="image-description">
@@ -249,12 +249,7 @@
               >henry_be</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/orange-flowers-IicyiaPYGGI"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/unveiling-magic-polar-expeditions.html
+++ b/articles/unveiling-magic-polar-expeditions.html
@@ -265,7 +265,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/green-mountain-across-body-of-water-Bkci_8qcdvQ" />
           </picture>
 
           <figcaption class="image-description">
@@ -277,12 +277,7 @@
               >kalenemsley</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/green-mountain-across-body-of-water-Bkci_8qcdvQ"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/visit-earth-extremities.html
+++ b/articles/visit-earth-extremities.html
@@ -247,7 +247,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/body-of-water-under-sky-6ArTTluciuA" />
           </picture>
 
           <figcaption class="image-description">
@@ -256,12 +256,7 @@
               >matthardy</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/body-of-water-under-sky-6ArTTluciuA"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/voluntourism-impactful-travel.html
+++ b/articles/voluntourism-impactful-travel.html
@@ -260,7 +260,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/airplane-on-sky-during-golden-hour-M0AWNxnLaMw" />
           </picture>
 
           <figcaption class="image-description">
@@ -272,12 +272,7 @@
               >wistomsin</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/airplane-on-sky-during-golden-hour-M0AWNxnLaMw"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>

--- a/articles/voyage-through-vineyards-global-wine-regions.html
+++ b/articles/voyage-through-vineyards-global-wine-regions.html
@@ -247,7 +247,7 @@
               height="400"
               fetchpriority="high"
               style="display: block; width: 100%; height: auto"
-            />
+             title="https://unsplash.com/photos/green-mountain-across-body-of-water-Bkci_8qcdvQ" />
           </picture>
 
           <figcaption class="image-description">
@@ -259,12 +259,7 @@
               >kalenemsley</a
             >
             from
-            <a
-              href="https://unsplash.com/photos/green-mountain-across-body-of-water-Bkci_8qcdvQ"
-              rel="nofollow noopener"
-              target="_blank"
-              >Unsplash</a
-            >
+            Unsplash
           </figcaption>
         </figure>
         <section>


### PR DESCRIPTION
## Summary
- remove visible Unsplash links from article captions
- store Unsplash photo URLs in the image `title` attribute for credit

## Testing
- `node scripts/update-search-index.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b1ac716c38832991671f75d7eee8a5