### PR TITLE
Add main navigation to headers

### DIFF
--- a/authors/danielle-eyebright.html
+++ b/authors/danielle-eyebright.html
@@ -21,7 +21,31 @@
   </head>
   <body>
     <header>
-      <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+      <nav aria-label="Main site navigation">
+        <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+        <ul class="site-nav">
+          <li>
+            <a href="/latest-articles.html"
+              >Latest Articles</a
+            >
+          </li>
+          <li>
+            <a href="/most-read-articles.html"
+              >Most Read Articles</a
+            >
+          </li>
+          <li>
+            <a href="/articles/top-10-hidden-gems-europe.html"
+              >Top Destinations</a
+            >
+          </li>
+          <li>
+            <a href="/articles/navigating-night-markets-food-lovers-guide.html"
+              >Editor’s Pick</a
+            >
+          </li>
+        </ul>
+      </nav>
       <hr />
     </header>
     <main class="author-main">

--- a/authors/daniil-kharms.html
+++ b/authors/daniil-kharms.html
@@ -21,7 +21,31 @@
   </head>
   <body>
     <header>
-      <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+      <nav aria-label="Main site navigation">
+        <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+        <ul class="site-nav">
+          <li>
+            <a href="/latest-articles.html"
+              >Latest Articles</a
+            >
+          </li>
+          <li>
+            <a href="/most-read-articles.html"
+              >Most Read Articles</a
+            >
+          </li>
+          <li>
+            <a href="/articles/top-10-hidden-gems-europe.html"
+              >Top Destinations</a
+            >
+          </li>
+          <li>
+            <a href="/articles/navigating-night-markets-food-lovers-guide.html"
+              >Editor’s Pick</a
+            >
+          </li>
+        </ul>
+      </nav>
       <hr />
     </header>
     <main class="author-main">

--- a/authors/david-agnew.html
+++ b/authors/david-agnew.html
@@ -21,7 +21,31 @@
   </head>
   <body>
     <header>
-      <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+      <nav aria-label="Main site navigation">
+        <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+        <ul class="site-nav">
+          <li>
+            <a href="/latest-articles.html"
+              >Latest Articles</a
+            >
+          </li>
+          <li>
+            <a href="/most-read-articles.html"
+              >Most Read Articles</a
+            >
+          </li>
+          <li>
+            <a href="/articles/top-10-hidden-gems-europe.html"
+              >Top Destinations</a
+            >
+          </li>
+          <li>
+            <a href="/articles/navigating-night-markets-food-lovers-guide.html"
+              >Editor’s Pick</a
+            >
+          </li>
+        </ul>
+      </nav>
       <hr />
     </header>
     <main class="author-main">

--- a/authors/davina-blake.html
+++ b/authors/davina-blake.html
@@ -21,7 +21,31 @@
   </head>
   <body>
     <header>
-      <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+      <nav aria-label="Main site navigation">
+        <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+        <ul class="site-nav">
+          <li>
+            <a href="/latest-articles.html"
+              >Latest Articles</a
+            >
+          </li>
+          <li>
+            <a href="/most-read-articles.html"
+              >Most Read Articles</a
+            >
+          </li>
+          <li>
+            <a href="/articles/top-10-hidden-gems-europe.html"
+              >Top Destinations</a
+            >
+          </li>
+          <li>
+            <a href="/articles/navigating-night-markets-food-lovers-guide.html"
+              >Editor’s Pick</a
+            >
+          </li>
+        </ul>
+      </nav>
       <hr />
     </header>
     <main class="author-main">

--- a/authors/frank-axton.html
+++ b/authors/frank-axton.html
@@ -21,7 +21,31 @@
   </head>
   <body>
     <header>
-      <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+      <nav aria-label="Main site navigation">
+        <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+        <ul class="site-nav">
+          <li>
+            <a href="/latest-articles.html"
+              >Latest Articles</a
+            >
+          </li>
+          <li>
+            <a href="/most-read-articles.html"
+              >Most Read Articles</a
+            >
+          </li>
+          <li>
+            <a href="/articles/top-10-hidden-gems-europe.html"
+              >Top Destinations</a
+            >
+          </li>
+          <li>
+            <a href="/articles/navigating-night-markets-food-lovers-guide.html"
+              >Editor’s Pick</a
+            >
+          </li>
+        </ul>
+      </nav>
       <hr />
     </header>
     <main class="author-main">

--- a/authors/lisa-crow.html
+++ b/authors/lisa-crow.html
@@ -21,7 +21,31 @@
   </head>
   <body>
     <header>
-      <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+      <nav aria-label="Main site navigation">
+        <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+        <ul class="site-nav">
+          <li>
+            <a href="/latest-articles.html"
+              >Latest Articles</a
+            >
+          </li>
+          <li>
+            <a href="/most-read-articles.html"
+              >Most Read Articles</a
+            >
+          </li>
+          <li>
+            <a href="/articles/top-10-hidden-gems-europe.html"
+              >Top Destinations</a
+            >
+          </li>
+          <li>
+            <a href="/articles/navigating-night-markets-food-lovers-guide.html"
+              >Editor’s Pick</a
+            >
+          </li>
+        </ul>
+      </nav>
       <hr />
     </header>
     <main class="author-main">

--- a/authors/shamina-cody.html
+++ b/authors/shamina-cody.html
@@ -21,7 +21,31 @@
   </head>
   <body>
     <header>
-      <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+      <nav aria-label="Main site navigation">
+        <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+        <ul class="site-nav">
+          <li>
+            <a href="/latest-articles.html"
+              >Latest Articles</a
+            >
+          </li>
+          <li>
+            <a href="/most-read-articles.html"
+              >Most Read Articles</a
+            >
+          </li>
+          <li>
+            <a href="/articles/top-10-hidden-gems-europe.html"
+              >Top Destinations</a
+            >
+          </li>
+          <li>
+            <a href="/articles/navigating-night-markets-food-lovers-guide.html"
+              >Editor’s Pick</a
+            >
+          </li>
+        </ul>
+      </nav>
       <hr />
     </header>
     <main class="author-main">

--- a/authors/susanna-lem.html
+++ b/authors/susanna-lem.html
@@ -21,7 +21,31 @@
   </head>
   <body>
     <header>
-      <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+      <nav aria-label="Main site navigation">
+        <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+        <ul class="site-nav">
+          <li>
+            <a href="/latest-articles.html"
+              >Latest Articles</a
+            >
+          </li>
+          <li>
+            <a href="/most-read-articles.html"
+              >Most Read Articles</a
+            >
+          </li>
+          <li>
+            <a href="/articles/top-10-hidden-gems-europe.html"
+              >Top Destinations</a
+            >
+          </li>
+          <li>
+            <a href="/articles/navigating-night-markets-food-lovers-guide.html"
+              >Editor’s Pick</a
+            >
+          </li>
+        </ul>
+      </nav>
       <hr />
     </header>
     <main class="author-main">

--- a/index.html
+++ b/index.html
@@ -113,6 +113,31 @@
           </form>
         </search>
       </div>
+      <nav aria-label="Main site navigation">
+        <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+        <ul class="site-nav">
+          <li>
+            <a href="/latest-articles.html"
+              >Latest Articles</a
+            >
+          </li>
+          <li>
+            <a href="/most-read-articles.html"
+              >Most Read Articles</a
+            >
+          </li>
+          <li>
+            <a href="/articles/top-10-hidden-gems-europe.html"
+              >Top Destinations</a
+            >
+          </li>
+          <li>
+            <a href="/articles/navigating-night-markets-food-lovers-guide.html"
+              >Editor’s Pick</a
+            >
+          </li>
+        </ul>
+      </nav>
       <hr />
     </header>
 

--- a/search-results.html
+++ b/search-results.html
@@ -48,7 +48,31 @@
   </head>
   <body>
     <header>
-      <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+      <nav aria-label="Main site navigation">
+        <a rel="home" href="/" id="title" aria-label="Travel Guide home"><picture class="logo"><source srcset="/assets/exitfloridakeys-logo.avif" type="image/avif" /><img src="/assets/exitfloridakeys-logo.png" alt="Travel Guide logo" class="logo" /></picture></a>
+        <ul class="site-nav">
+          <li>
+            <a href="/latest-articles.html"
+              >Latest Articles</a
+            >
+          </li>
+          <li>
+            <a href="/most-read-articles.html"
+              >Most Read Articles</a
+            >
+          </li>
+          <li>
+            <a href="/articles/top-10-hidden-gems-europe.html"
+              >Top Destinations</a
+            >
+          </li>
+          <li>
+            <a href="/articles/navigating-night-markets-food-lovers-guide.html"
+              >Editor’s Pick</a
+            >
+          </li>
+        </ul>
+      </nav>
       <hr />
     </header>
 


### PR DESCRIPTION
## Summary
- Embed shared main navigation inside index header after the logo and search block
- Replace standalone logo headers on author and search results pages with full site navigation
- Ensure links to Latest and Most Read articles point to their dedicated pages

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b150f9d083298505a94a9dc6ebd3