### PR TITLE
feat: generate latest articles page

### DIFF
--- a/latest-articles.html
+++ b/latest-articles.html
@@ -49,33 +49,104 @@
       <h1>Latest Articles</h1>
       <section id="results">
     <div class="card">
-      <a aria-label="a family bonding activity on a piece of paper next to a typewriter" href="/articles/ultimate-family-solo-travel-planning-tips-2025.html">
+      <a aria-label="aerial photography of body of water during daytime" href="/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html">
         <picture>
-          <img src="https://images.unsplash.com/photo-1695313486156-469b82f59e07?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxmYW1pbHklMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUwNTQzNTA0fDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1695313486156-469b82f59e07?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxmYW1pbHklMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUwNTQzNTA0fDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
-                https://images.unsplash.com/photo-1695313486156-469b82f59e07?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxmYW1pbHklMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUwNTQzNTA0fDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="a family bonding activity on a piece of paper next to a typewriter" loading="lazy" decoding="async" width="1300" height="500" />
+          <img src="https://images.unsplash.com/photo-1520285774798-2f1616131a68?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxsdXh1cnklMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnMlMjAyMDI1fGVufDB8MHx8fDE3NTE4ODI0NDN8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1520285774798-2f1616131a68?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxsdXh1cnklMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnMlMjAyMDI1fGVufDB8MHx8fDE3NTE4ODI0NDN8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1520285774798-2f1616131a68?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxsdXh1cnklMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnMlMjAyMDI1fGVufDB8MHx8fDE3NTE4ODI0NDN8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="aerial photography of body of water during daytime" loading="lazy" decoding="async" width="1300" height="500" />
         </picture>
       </a>
 
-      <h3><a href="/articles/ultimate-family-solo-travel-planning-tips-2025.html">Ultimate Family and Solo Travel Planning: Tips and
-      Destinations for 2025</a></h3>
+      <h3><a href="/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html">Ultimate Travel Guide: Tips, Destinations, and Insider Experiences for 2025</a></h3>
 
       <div id="published">
         Published:
-        <em><time itemprop="datePublished" datetime="2025-06-21">
-            June 21, 2025</time></em>
+        <em><time itemprop="datePublished" datetime="2025-07-07">
+            July 7, 2025</time></em>
       </div>
 
-      <p>Planning your 2025 adventures just got easier with expert tips for both family trips and solo journeys that promise unforgettable experiences. Dive into essential travel advice starting with how to create lasting memories during family vacations that everyone will cherish.</p>
+      <p>Get ready to unlock the secrets of unforgettable adventures with our Ultimate Travel Guide for 2025, packed with tips, top destinations, and insider experiences. From expert advice to exciting places, let’s dive into essential travel tips that will elevate your next journey.</p>
     </div>
     <div class="card">
-      <a aria-label="a bus driving through a canyon" href="/articles/explore-enchanting-destinations-smart-travel-planning-2025.html">
+      <a aria-label="black and gray camera on open map" href="/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html">
         <picture>
-          <img src="https://images.unsplash.com/photo-1669399554927-cc38ca6bc3ba?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlbmNoYW50aW5nJTIwdHJhdmVsJTIwZGVzdGluYXRpb25zJTIwMjAyNXxlbnwwfDB8fHwxNzU1MjYyODM2fDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1669399554927-cc38ca6bc3ba?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlbmNoYW50aW5nJTIwdHJhdmVsJTIwZGVzdGluYXRpb25zJTIwMjAyNXxlbnwwfDB8fHwxNzU1MjYyODM2fDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
-                https://images.unsplash.com/photo-1669399554927-cc38ca6bc3ba?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlbmNoYW50aW5nJTIwdHJhdmVsJTIwZGVzdGluYXRpb25zJTIwMjAyNXxlbnwwfDB8fHwxNzU1MjYyODM2fDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="a bus driving through a canyon" loading="lazy" decoding="async" width="1300" height="500" />
+          <img src="https://images.unsplash.com/photo-1503220954697-e02095e8e0d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUzNjE3MzIxfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1503220954697-e02095e8e0d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUzNjE3MzIxfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1503220954697-e02095e8e0d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUzNjE3MzIxfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="black and gray camera on open map" loading="lazy" decoding="async" width="1300" height="500" />
         </picture>
       </a>
 
-      <h3><a href="/articles/explore-enchanting-destinations-smart-travel-planning-2025.html">Explore Enchanting Destinations and Smart Travel Planning Tips for 2025</a></h3>
+      <h3><a href="/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html">Mastering Travel Flexibility: Tips and Inspiring Stories for Adventurous Journeys</a></h3>
+
+      <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="2025-07-27">
+            July 27, 2025</time></em>
+      </div>
+
+      <p>Mastering travel flexibility unlocks thrilling adventures and opens the door to unforgettable experiences. Let’s dive into embracing unpredictability and start with how flexibility fuels adventurous journeys.</p>
+    </div>
+    <div class="card">
+      <a aria-label="people standing on brown sand under blue sky during daytime" href="/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html">
+        <picture>
+          <img src="https://images.unsplash.com/photo-1608984075444-0e67cd80f696?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwdHJhdmVsJTIwbGFuZHNjYXBlc3xlbnwwfDB8fHwxNzUxODM5MjUyfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1608984075444-0e67cd80f696?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwdHJhdmVsJTIwbGFuZHNjYXBlc3xlbnwwfDB8fHwxNzUxODM5MjUyfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1608984075444-0e67cd80f696?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwdHJhdmVsJTIwbGFuZHNjYXBlc3xlbnwwfDB8fHwxNzUxODM5MjUyfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="people standing on brown sand under blue sky during daytime" loading="lazy" decoding="async" width="1300" height="500" />
+        </picture>
+      </a>
+
+      <h3><a href="/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html">Unforgettable Travel Stories and Expert Tips for 2025 Adventures</a></h3>
+
+      <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="2025-07-06">
+            July 6, 2025</time></em>
+      </div>
+
+      <p>Unforgettable travel stories ignite the passion for exploring new horizons, offering inspiration for your 2025 adventures. Dive into remarkable experiences and expert tips that set the stage for safe, culturally rich journeys ahead.</p>
+    </div>
+    <div class="card">
+      <a aria-label="a group of people walking down a hallway" href="/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html">
+        <picture>
+          <img src="https://images.unsplash.com/photo-1647161407063-d49d91a5e6b8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHklMjBjdWx0dXJhbCUyMGRpdmVyc2l0eSUyMHVuaXF1ZSUyMGRlc3RpbmF0aW9ucyUyMDIwMjV8ZW58MHwwfHx8MTc1MTk2ODg1OXww&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1647161407063-d49d91a5e6b8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHklMjBjdWx0dXJhbCUyMGRpdmVyc2l0eSUyMHVuaXF1ZSUyMGRlc3RpbmF0aW9ucyUyMDIwMjV8ZW58MHwwfHx8MTc1MTk2ODg1OXww&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1647161407063-d49d91a5e6b8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHklMjBjdWx0dXJhbCUyMGRpdmVyc2l0eSUyMHVuaXF1ZSUyMGRlc3RpbmF0aW9ucyUyMDIwMjV8ZW58MHwwfHx8MTc1MTk2ODg1OXww&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="a group of people walking down a hallway" loading="lazy" decoding="async" width="1300" height="500" />
+        </picture>
+      </a>
+
+      <h3><a href="/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html">Navigating Modern Travel: Safety, Culture, and Unique Destinations in 2025</a></h3>
+
+      <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="2025-07-08">
+            July 8, 2025</time></em>
+      </div>
+
+      <p>Modern travel in 2025 presents new challenges and exciting opportunities that require careful planning. From ensuring safety to embracing cultural immersion, this guide begins with essential travel safety tips for a secure journey.</p>
+    </div>
+    <div class="card">
+      <a aria-label="a traffic light on a pole with a sky background" href="/articles/navigating-modern-travel-safety-tips-destinations-experiences.html">
+        <picture>
+          <img src="https://images.unsplash.com/photo-1718242869012-34c2587f50aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHl8ZW58MHwwfHx8MTc1MjA3OTU0Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1718242869012-34c2587f50aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHl8ZW58MHwwfHx8MTc1MjA3OTU0Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1718242869012-34c2587f50aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHl8ZW58MHwwfHx8MTc1MjA3OTU0Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="a traffic light on a pole with a sky background" loading="lazy" decoding="async" width="1300" height="500" />
+        </picture>
+      </a>
+
+      <h3><a href="/articles/navigating-modern-travel-safety-tips-destinations-experiences.html">Navigating Modern Travel: Safety Tips, Destinations, and Experiences</a></h3>
+
+      <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="2025-07-09">
+            July 9, 2025</time></em>
+      </div>
+
+      <p>Navigating modern travel requires a balance of excitement and caution as new challenges and opportunities arise. This guide will equip you with essential safety tips and practical advice to handle disruptions, empowering you to explore top destinations with confidence.</p>
+    </div>
+    <div class="card">
+      <a aria-label="man wearing white shirt overlooking on white clouds" href="/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html">
+        <picture>
+          <img src="https://images.unsplash.com/photo-1612257998531-70e0d0a15f6d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTUyNjI0OTJ8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1612257998531-70e0d0a15f6d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTUyNjI0OTJ8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1612257998531-70e0d0a15f6d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTUyNjI0OTJ8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="man wearing white shirt overlooking on white clouds" loading="lazy" decoding="async" width="1300" height="500" />
+        </picture>
+      </a>
+
+      <h3><a href="/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html">Navigating Modern Travel: Experiences, Challenges, and Emerging Destinations</a></h3>
 
       <div id="published">
         Published:
@@ -83,115 +154,43 @@
             August 15, 2025</time></em>
       </div>
 
-      <p>Discover the most enchanting travel destinations set to captivate adventurers in 2025, paired with smart planning tips to make every trip seamless. From unique locales to insider advice, this guide will inspire your next unforgettable journey.</p>
+      <p>Navigating the world of modern travel introduces a mix of exciting experiences and unexpected challenges. This article begins by exploring key travel experiences in 2025 that set the stage for contemporary journeys.</p>
     </div>
     <div class="card">
-      <a aria-label="A large brick building sitting on top of a dry grass field" href="/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html">
+      <a aria-label="the word travel spelled with scrabbles on a wooden table" href="/articles/discover-transformative-travel-stories-trending-destinations.html">
         <picture>
-          <img src="https://images.unsplash.com/photo-1739918586913-249d35cd5af2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjByZW1vdGUlMjBkZXN0aW5hdGlvbnN8ZW58MHwwfHx8MTc1MTAxODY1Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1739918586913-249d35cd5af2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjByZW1vdGUlMjBkZXN0aW5hdGlvbnN8ZW58MHwwfHx8MTc1MTAxODY1Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
-                https://images.unsplash.com/photo-1739918586913-249d35cd5af2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjByZW1vdGUlMjBkZXN0aW5hdGlvbnN8ZW58MHwwfHx8MTc1MTAxODY1Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="A large brick building sitting on top of a dry grass field" loading="lazy" decoding="async" width="1300" height="500" />
+          <img src="https://images.unsplash.com/photo-1673515335086-c762bbd7a7cf?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx0cmFuc2Zvcm1hdGl2ZSUyMHRyYXZlbCUyMGV4cGVyaWVuY2V8ZW58MHwwfHx8MTc1MTcwOTY1NHww&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1673515335086-c762bbd7a7cf?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx0cmFuc2Zvcm1hdGl2ZSUyMHRyYXZlbCUyMGV4cGVyaWVuY2V8ZW58MHwwfHx8MTc1MTcwOTY1NHww&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1673515335086-c762bbd7a7cf?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx0cmFuc2Zvcm1hdGl2ZSUyMHRyYXZlbCUyMGV4cGVyaWVuY2V8ZW58MHwwfHx8MTc1MTcwOTY1NHww&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="the word travel spelled with scrabbles on a wooden table" loading="lazy" decoding="async" width="1300" height="500" />
         </picture>
       </a>
 
-      <h3><a href="/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html">Unforgettable Travel Adventures: Exploring Unique Destinations Safely</a></h3>
+      <h3><a href="/articles/discover-transformative-travel-stories-trending-destinations.html">Discover Transformative Travel Stories and Top Trending Destinations</a></h3>
 
       <div id="published">
         Published:
-        <em><time itemprop="datePublished" datetime="2025-06-27">
-            June 27, 2025</time></em>
+        <em><time itemprop="datePublished" datetime="2025-07-05">
+            July 5, 2025</time></em>
       </div>
 
-      <p>Escape the usual tourist trails and immerse yourself in unforgettable travel adventures that celebrate unique destinations. Let’s embark on a journey to discover exclusive experiences while ensuring your safety every step of the way.</p>
+      <p>Transformative travel stories reveal how exploring new destinations can spark personal growth and unforgettable adventures. Let’s dive into how embracing these experiences can change your perspective and explore the top trending travel destinations for 2025.</p>
     </div>
     <div class="card">
-      <a aria-label="orange flowers" href="/articles/unplugged-adventures-travel-without-technology.html">
+      <a aria-label="people gathering near the hut lot during daytime" href="/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html">
         <picture>
-          <img src="https://images.unsplash.com/photo-1465146344425-f00d5f5c8f07?crop=entropy&cs=tinysrgb&fit=crop&fm=avif&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxuYXR1cmUlMjB0cmF2ZWwlMjBhZHZlbnR1cmUlMjBvZmZsaW5lJTIwZXhwbG9yYXRpb258ZW58MHx8fHwxNzQ1MjM1NTI5fDA&ixlib=rb-4.0.3&q=80&w=1300" srcset="https://images.unsplash.com/photo-1465146344425-f00d5f5c8f07?crop=entropy&cs=tinysrgb&fit=crop&fm=avif&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxuYXR1cmUlMjB0cmF2ZWwlMjBhZHZlbnR1cmUlMjBvZmZsaW5lJTIwZXhwbG9yYXRpb258ZW58MHx8fHwxNzQ1MjM1NTI5fDA&ixlib=rb-4.0.3&q=80&w=1300&dpr=2 2x,
-                https://images.unsplash.com/photo-1465146344425-f00d5f5c8f07?crop=entropy&cs=tinysrgb&fit=crop&fm=avif&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxuYXR1cmUlMjB0cmF2ZWwlMjBhZHZlbnR1cmUlMjBvZmZsaW5lJTIwZXhwbG9yYXRpb258ZW58MHx8fHwxNzQ1MjM1NTI5fDA&ixlib=rb-4.0.3&q=80&w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="orange flowers" loading="lazy" decoding="async" width="1300" height="500" />
+          <img src="https://images.unsplash.com/photo-1560643248-d9c6124b2a44?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3aW5kaW5nJTIwbW91bnRhaW4lMjByb2FkcyUyMHJlbW90ZSUyMHZpbGxhZ2UlMjBjdWx0dXJhbCUyMGZlc3RpdmFsfGVufDB8MHx8fDE3NTMxOTAwNzR8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1560643248-d9c6124b2a44?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3aW5kaW5nJTIwbW91bnRhaW4lMjByb2FkcyUyMHJlbW90ZSUyMHZpbGxhZ2UlMjBjdWx0dXJhbCUyMGZlc3RpdmFsfGVufDB8MHx8fDE3NTMxOTAwNzR8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1560643248-d9c6124b2a44?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3aW5kaW5nJTIwbW91bnRhaW4lMjByb2FkcyUyMHJlbW90ZSUyMHZpbGxhZ2UlMjBjdWx0dXJhbCUyMGZlc3RpdmFsfGVufDB8MHx8fDE3NTMxOTAwNzR8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="people gathering near the hut lot during daytime" loading="lazy" decoding="async" width="1300" height="500" />
         </picture>
       </a>
 
-      <h3><a href="/articles/unplugged-adventures-travel-without-technology.html">Unplugged Adventures Experiencing Travel Without Technology</a></h3>
+      <h3><a href="/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html">Navigating Global Travel: Unique Destinations, Challenges, and Cultural Insights</a></h3>
 
       <div id="published">
         Published:
-        <em><time itemprop="datePublished" datetime="2024-12-01">
-            December 1, 2024</time></em>
+        <em><time itemprop="datePublished" datetime="2025-07-22">
+            July 22, 2025</time></em>
       </div>
 
-      <p>Breaking free from screens and digital devices opens up new dimensions of discovery. Embarking on unplugged adventures allows travelers to reconnect with nature, local cultures, and themselves, creating memories far richer than those captured behind a screen.</p>
-    </div>
-    <div class="card">
-      <a aria-label="flat lay photography of sliced apples, sausages, chips and brown sauce" href="/articles/going-green-vegan-vegetarian-travel.html">
-        <picture>
-          <img src="https://images.unsplash.com/photo-1485963631004-f2f00b1d6606?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx2ZWdhbiUyMHRyYXZlbCUyMHBsYW50LWJhc2VkJTIwZm9vZCUyMGVjby1mcmllbmRseSUyMHRyYXZlbCUyMGRlc3RpbmF0aW9uJTIwbmF0dXJlfGVufDB8fHx8MTc0NTQ0MjQyMXww&ixlib=rb-4.0.3&q=80&w=1300&h=500" srcset="https://images.unsplash.com/photo-1485963631004-f2f00b1d6606?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx2ZWdhbiUyMHRyYXZlbCUyMHBsYW50LWJhc2VkJTIwZm9vZCUyMGVjby1mcmllbmRseSUyMHRyYXZlbCUyMGRlc3RpbmF0aW9uJTIwbmF0dXJlfGVufDB8fHx8MTc0NTQ0MjQyMXww&ixlib=rb-4.0.3&q=80&w=1300&h=500&dpr=2 2x,
-                https://images.unsplash.com/photo-1485963631004-f2f00b1d6606?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx2ZWdhbiUyMHRyYXZlbCUyMHBsYW50LWJhc2VkJTIwZm9vZCUyMGVjby1mcmllbmRseSUyMHRyYXZlbCUyMGRlc3RpbmF0aW9uJTIwbmF0dXJlfGVufDB8fHx8MTc0NTQ0MjQyMXww&ixlib=rb-4.0.3&q=80&w=1300&h=500 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="flat lay photography of sliced apples, sausages, chips and brown sauce" loading="lazy" decoding="async" width="1300" height="500" />
-        </picture>
-      </a>
-
-      <h3><a href="/articles/going-green-vegan-vegetarian-travel.html">Going Green: The Rise of Vegan and Vegetarian Travel</a></h3>
-
-      <div id="published">
-        Published:
-        <em><time itemprop="datePublished" datetime="2025-04-18">
-            April 18, 2025</time></em>
-      </div>
-
-      <p>The movement towards vegan and vegetarian travel reflects a growing commitment to sustainability, ethics, and personal health. Travelers are increasingly seeking destinations that align with their plant-based lifestyles, fostering a more conscious approach to exploring the world. This shift influences local cuisines, sustainable practices, and overall travel experiences, making it an exciting trend for eco-aware adventurers.</p>
-    </div>
-    <div class="card">
-      <a aria-label="a man pushing a cart full of bags down a street" href="/articles/unplanned-journeys-travel-realities-insights.html">
-        <picture>
-          <img src="https://images.unsplash.com/photo-1638745391040-15f6eb812215?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxjYW5kaWQlMjB0cmF2ZWxlcnMlMjBiYWNrcGFja2luZyUyMGNpdHklMjBzdHJlZXRzfGVufDB8MHx8fDE3NTE2NjY3NDB8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1638745391040-15f6eb812215?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxjYW5kaWQlMjB0cmF2ZWxlcnMlMjBiYWNrcGFja2luZyUyMGNpdHklMjBzdHJlZXRzfGVufDB8MHx8fDE3NTE2NjY3NDB8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
-                https://images.unsplash.com/photo-1638745391040-15f6eb812215?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxjYW5kaWQlMjB0cmF2ZWxlcnMlMjBiYWNrcGFja2luZyUyMGNpdHklMjBzdHJlZXRzfGVufDB8MHx8fDE3NTE2NjY3NDB8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="a man pushing a cart full of bags down a street" loading="lazy" decoding="async" width="1300" height="500" />
-        </picture>
-      </a>
-
-      <h3><a href="/articles/unplanned-journeys-travel-realities-insights.html">Unplanned Journeys and Travel Realities: Insights for Savvy Adventurers</a></h3>
-
-      <div id="published">
-        Published:
-        <em><time itemprop="datePublished" datetime="2025-07-04">
-            July 4, 2025</time></em>
-      </div>
-
-      <p>Travel often leads us down unexpected paths, revealing the true nature of unplanned journeys and travel realities. This article dives into embracing surprise destinations and mastering the practical challenges that come with them.</p>
-    </div>
-    <div class="card">
-      <a aria-label="person holding silver iPhone 6" href="/articles/best-travel-apps.html">
-        <picture>
-          <img src="https://images.unsplash.com/photo-1528033978085-52f315289665?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx0cmF2ZWwlMjBhcHBzJTIwb24lMjBzbWFydHBob25lfGVufDB8fHx8MTc0NDkzMTUxNnww&ixlib=rb-4.0.3&q=80&w=1300" srcset="https://images.unsplash.com/photo-1528033978085-52f315289665?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx0cmF2ZWwlMjBhcHBzJTIwb24lMjBzbWFydHBob25lfGVufDB8fHx8MTc0NDkzMTUxNnww&ixlib=rb-4.0.3&q=80&w=1300&dpr=2 2x,
-                https://images.unsplash.com/photo-1528033978085-52f315289665?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx0cmF2ZWwlMjBhcHBzJTIwb24lMjBzbWFydHBob25lfGVufDB8fHx8MTc0NDkzMTUxNnww&ixlib=rb-4.0.3&q=80&w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="person holding silver iPhone 6" loading="lazy" decoding="async" width="1300" height="500" />
-        </picture>
-      </a>
-
-      <h3><a href="/articles/best-travel-apps.html">Best Travel Apps to Make Your Journey Easier</a></h3>
-
-      <div id="published">
-        Published:
-        <em><time itemprop="datePublished" datetime="2025-01-26">
-            January 26, 2025</time></em>
-      </div>
-
-      <p>Travel apps have become indispensable for explorers seeking convenience and confidence on their journeys. These digital tools simplify logistics, improve safety, and enrich experiences, making every trip smoother and more enjoyable. Explore the top apps everyone should have to navigate the world with ease.</p>
-    </div>
-    <div class="card">
-      <a aria-label="photo of two mountains" href="/articles/traveling-without-trace.html">
-        <picture>
-          <img src="https://images.unsplash.com/photo-1714188764655-f002141b25d1?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxuYXR1cmUlMjBjYW1waW5nJTIwaGlraW5nJTIwb3V0ZG9vciUyMGVjbyUyMGNvbnNlcnZhdGlvbnxlbnwwfHx8fDE3NDU0NDIzNjZ8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500" srcset="https://images.unsplash.com/photo-1714188764655-f002141b25d1?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxuYXR1cmUlMjBjYW1waW5nJTIwaGlraW5nJTIwb3V0ZG9vciUyMGVjbyUyMGNvbnNlcnZhdGlvbnxlbnwwfHx8fDE3NDU0NDIzNjZ8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500&dpr=2 2x,
-                https://images.unsplash.com/photo-1714188764655-f002141b25d1?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxuYXR1cmUlMjBjYW1waW5nJTIwaGlraW5nJTIwb3V0ZG9vciUyMGVjbyUyMGNvbnNlcnZhdGlvbnxlbnwwfHx8fDE3NDU0NDIzNjZ8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="photo of two mountains" loading="lazy" decoding="async" width="1300" height="500" />
-        </picture>
-      </a>
-
-      <h3><a href="/articles/traveling-without-trace.html">Traveling Without a Trace: A Guide to Leave No Trace Principles</a></h3>
-
-      <div id="published">
-        Published:
-        <em><time itemprop="datePublished" datetime="2025-04-16">
-            April 16, 2025</time></em>
-      </div>
-
-      <p>Embarking on outdoor adventures offers unparalleled connection with nature. By applying Leave No Trace principles, travelers can enjoy pristine environments while preserving them for others. This guide explores practical steps to minimize your footprint, promote sustainability, and ensure that natural spaces remain unspoiled for generations to come. Responsible travel begins with mindful habits and respectful behavior.</p>
+      <p>Global travel invites explorers to venture beyond typical tourist spots, uncovering unique destinations rich in culture and challenge. This journey begins by exploring off-the-beaten-path locations that reveal authentic experiences and set the stage for meaningful adventures.</p>
     </div>
       </section>
     </main>

--- a/scripts/update-random-articles.mjs
+++ b/scripts/update-random-articles.mjs
@@ -3,10 +3,7 @@ import { join } from "node:path";
 
 const root = process.cwd();
 const dataFile = join(root, "assets", "search.json");
-const pages = [
-  join(root, "latest-articles.html"),
-  join(root, "most-read-articles.html"),
-];
+const pages = [join(root, "most-read-articles.html")];
 
 const searchData = JSON.parse(await readFile(dataFile, "utf8"));
 


### PR DESCRIPTION
## Summary
- extend latest-posts updater to also refresh `latest-articles.html`
- randomize 5-10 latest articles for the dedicated page
- limit random-articles script to most-read page

## Testing
- `node scripts/update-latest-posts.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b1b15ae81c832987bda47bce6b5172