### PR TITLE
Add Unsplash attribution to imprint

### DIFF
--- a/imprint.html
+++ b/imprint.html
@@ -107,6 +107,14 @@
           copyright law. Any reproduction requires the prior written consent of
           the copyright holder.
         </p>
+        <p>
+          Unless otherwise indicated, all photographs displayed on this site
+          are sourced from
+          <a href="https://unsplash.com" rel="nofollow">Unsplash</a> and are
+          used pursuant to the
+          <a href="https://unsplash.com/license" rel="nofollow">Unsplash
+            License</a>.
+        </p>
       </section>
     </main>
 


### PR DESCRIPTION
## Summary
- note that all pictures on the site come from Unsplash in imprint/terms page with a link and legal wording

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b3b95ae08329876b25dd1254b41b