### PR TITLE
Lazy load second images in articles

### DIFF
--- a/articles/african-safari-experience-a-journey-into-the-wild.html
+++ b/articles/african-safari-experience-a-journey-into-the-wild.html
@@ -264,7 +264,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=665049" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=665049&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=665049 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/architectural-marvels-modern-wonders-world.html
+++ b/articles/architectural-marvels-modern-wonders-world.html
@@ -278,7 +278,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=769338" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=769338&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=769338 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/behind-scenes-worlds-largest-festivals.html
+++ b/articles/behind-scenes-worlds-largest-festivals.html
@@ -275,7 +275,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=14746" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=14746&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=14746 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/best-safari-destinations.html
+++ b/articles/best-safari-destinations.html
@@ -273,7 +273,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=431621" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=431621&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=431621 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/best-travel-apps.html
+++ b/articles/best-travel-apps.html
@@ -263,7 +263,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=271717" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=271717&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=271717 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/beyond-hostels-hotels-unique-accommodations-adventurous-traveler.html
+++ b/articles/beyond-hostels-hotels-unique-accommodations-adventurous-traveler.html
@@ -276,7 +276,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=775865" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=775865&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=775865 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/chasing-northern-lights-best-places.html
+++ b/articles/chasing-northern-lights-best-places.html
@@ -285,7 +285,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=352260" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=352260&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=352260 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/culinary-trails-origins-iconic-street-food.html
+++ b/articles/culinary-trails-origins-iconic-street-food.html
@@ -287,7 +287,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=259282" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=259282&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=259282 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/cultural-immersion-experiences.html
+++ b/articles/cultural-immersion-experiences.html
@@ -266,7 +266,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=85352" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=85352&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=85352 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/dark-tourism-worlds-haunting-locations.html
+++ b/articles/dark-tourism-worlds-haunting-locations.html
@@ -270,7 +270,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=119495" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=119495&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=119495 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/digital-nomad-life-world.html
+++ b/articles/digital-nomad-life-world.html
@@ -289,7 +289,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=292559" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=292559&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=292559 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/discover-transformative-travel-stories-trending-destinations.html
+++ b/articles/discover-transformative-travel-stories-trending-destinations.html
@@ -370,7 +370,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=662265" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=662265&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=662265 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/discovering-underwater-world-best-snorkeling-spots-globally.html
+++ b/articles/discovering-underwater-world-best-snorkeling-spots-globally.html
@@ -257,7 +257,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=452892" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=452892&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=452892 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/eco-friendly-traveling-world-sustainably.html
+++ b/articles/eco-friendly-traveling-world-sustainably.html
@@ -414,7 +414,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=656981" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=656981&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=656981 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/embracing-eco-tourism-sustainable-journey-costa-rica.html
+++ b/articles/embracing-eco-tourism-sustainable-journey-costa-rica.html
@@ -271,7 +271,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=265303" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=265303&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=265303 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/explore-enchanting-destinations-smart-travel-planning-2025.html
+++ b/articles/explore-enchanting-destinations-smart-travel-planning-2025.html
@@ -381,7 +381,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=132299" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=132299&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=132299 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/explore-unique-travel-experiences-hidden-gems-2025.html
+++ b/articles/explore-unique-travel-experiences-hidden-gems-2025.html
@@ -330,7 +330,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=913596" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=913596&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=913596 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/exploring-arctic-travel-guide.html
+++ b/articles/exploring-arctic-travel-guide.html
@@ -280,7 +280,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=514411" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=514411&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=514411 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/exploring-authentic-travel-experiences-hidden-gems-challenges.html
+++ b/articles/exploring-authentic-travel-experiences-hidden-gems-challenges.html
@@ -329,7 +329,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=218794" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=218794&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=218794 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/exploring-emerging-travel-trends-and-unique-hobby-inspirations.html
+++ b/articles/exploring-emerging-travel-trends-and-unique-hobby-inspirations.html
@@ -369,7 +369,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=416500" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=416500&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=416500 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/exploring-emerging-travel-trends-unique-hobby-inspirations.html
+++ b/articles/exploring-emerging-travel-trends-unique-hobby-inspirations.html
@@ -360,7 +360,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=853281" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=853281&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=853281 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/exploring-new-horizons-top-travel-tips-destinations-2025.html
+++ b/articles/exploring-new-horizons-top-travel-tips-destinations-2025.html
@@ -335,7 +335,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=154260" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=154260&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=154260 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/exploring-scottish-highlands.html
+++ b/articles/exploring-scottish-highlands.html
@@ -288,7 +288,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=192374" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=192374&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=192374 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/exploring-trending-travel-destinations-and-relaxing-hobby-ideas.html
+++ b/articles/exploring-trending-travel-destinations-and-relaxing-hobby-ideas.html
@@ -376,7 +376,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=384839" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=384839&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=384839 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/exploring-unesco-sites.html
+++ b/articles/exploring-unesco-sites.html
@@ -291,7 +291,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=283047" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=283047&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=283047 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/exploring-unique-destinations-travel-experiences-2025.html
+++ b/articles/exploring-unique-destinations-travel-experiences-2025.html
@@ -384,7 +384,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=716265" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=716265&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=716265 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/exploring-untouched-forests.html
+++ b/articles/exploring-untouched-forests.html
@@ -273,7 +273,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=661310" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=661310&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=661310 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/exploring-worlds-historical-walking-routes.html
+++ b/articles/exploring-worlds-historical-walking-routes.html
@@ -282,7 +282,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=925962" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=925962&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=925962 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/exploring-worlds-most-religious-sites.html
+++ b/articles/exploring-worlds-most-religious-sites.html
@@ -278,7 +278,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=982373" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=982373&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=982373 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/glamping-world-luxury-tents-incredible-views.html
+++ b/articles/glamping-world-luxury-tents-incredible-views.html
@@ -280,7 +280,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=530314" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=530314&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=530314 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/global-gastronomy-tasting-traditional-dishes-different-cultures.html
+++ b/articles/global-gastronomy-tasting-traditional-dishes-different-cultures.html
@@ -294,7 +294,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=841013" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=841013&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=841013 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/going-green-vegan-vegetarian-travel.html
+++ b/articles/going-green-vegan-vegetarian-travel.html
@@ -284,7 +284,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=416871" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=416871&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=416871 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/hidden-gems-uncharted-travel-destinations.html
+++ b/articles/hidden-gems-uncharted-travel-destinations.html
@@ -273,7 +273,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=449111" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=449111&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=449111 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/historic-railways-world-journey.html
+++ b/articles/historic-railways-world-journey.html
@@ -279,7 +279,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=796884" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=796884&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=796884 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/inspiring-travel-destinations-tips-2025-adventures.html
+++ b/articles/inspiring-travel-destinations-tips-2025-adventures.html
@@ -265,7 +265,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=488123" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=488123&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=488123 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/navigating-complexities-of-travel-tips-tales-realities.html
+++ b/articles/navigating-complexities-of-travel-tips-tales-realities.html
@@ -326,7 +326,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=353145" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=353145&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=353145 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html
+++ b/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html
@@ -381,7 +381,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=701917" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=701917&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=701917 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html
+++ b/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html
@@ -414,7 +414,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=566211" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=566211&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=566211 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/navigating-modern-travel-insights-experiences-tips-2025.html
+++ b/articles/navigating-modern-travel-insights-experiences-tips-2025.html
@@ -369,7 +369,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=556219" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=556219&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=556219 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html
+++ b/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html
@@ -326,7 +326,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=485154" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=485154&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=485154 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/navigating-modern-travel-safety-tips-destinations-experiences.html
+++ b/articles/navigating-modern-travel-safety-tips-destinations-experiences.html
@@ -379,7 +379,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=477093" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=477093&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=477093 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/navigating-night-markets-food-lovers-guide.html
+++ b/articles/navigating-night-markets-food-lovers-guide.html
@@ -288,7 +288,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=273779" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=273779&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=273779 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/navigating-realities-wonders-modern-travel-2025.html
+++ b/articles/navigating-realities-wonders-modern-travel-2025.html
@@ -380,7 +380,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=183897" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=183897&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=183897 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/navigating-solo-journeys-travel-challenges-2025.html
+++ b/articles/navigating-solo-journeys-travel-challenges-2025.html
@@ -326,7 +326,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=430261" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=430261&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=430261 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html
+++ b/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html
@@ -379,7 +379,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=200307" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=200307&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=200307 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/pedal-paradises-destinations-cycling-enthusiasts.html
+++ b/articles/pedal-paradises-destinations-cycling-enthusiasts.html
@@ -282,7 +282,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=145876" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=145876&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=145876 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/river-cruises-europe.html
+++ b/articles/river-cruises-europe.html
@@ -272,7 +272,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=53483" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=53483&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=53483 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/roaming-roof-world-himalayas-guide.html
+++ b/articles/roaming-roof-world-himalayas-guide.html
@@ -281,7 +281,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=832170" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=832170&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=832170 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/sanctuaries-sky-worlds-picturesque-mountain-retreats.html
+++ b/articles/sanctuaries-sky-worlds-picturesque-mountain-retreats.html
@@ -272,7 +272,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=465108" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=465108&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=465108 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/solo-travel-guide-southeast-asia-safety.html
+++ b/articles/solo-travel-guide-southeast-asia-safety.html
@@ -265,7 +265,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=331506" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=331506&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=331506 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/solo-travel-safety-guide.html
+++ b/articles/solo-travel-safety-guide.html
@@ -264,7 +264,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=635620" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=635620&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=635620 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/sustainable-food-explorations.html
+++ b/articles/sustainable-food-explorations.html
@@ -284,7 +284,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=372557" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=372557&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=372557 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/timeless-timelines-history-iconic-landmarks.html
+++ b/articles/timeless-timelines-history-iconic-landmarks.html
@@ -275,7 +275,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=712994" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=712994&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=712994 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/top-10-hidden-gems-europe.html
+++ b/articles/top-10-hidden-gems-europe.html
@@ -271,7 +271,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=609213" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=609213&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=609213 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/top-surfing-destinations-world.html
+++ b/articles/top-surfing-destinations-world.html
@@ -264,7 +264,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=428638" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=428638&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=428638 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/touring-tropics-comprehensive-guide.html
+++ b/articles/touring-tropics-comprehensive-guide.html
@@ -269,7 +269,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=250185" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=250185&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=250185 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/transcontinental-trails-world.html
+++ b/articles/transcontinental-trails-world.html
@@ -283,7 +283,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=708674" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=708674&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=708674 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/travel-budget-tips.html
+++ b/articles/travel-budget-tips.html
@@ -273,7 +273,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=923326" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=923326&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=923326 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html
+++ b/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html
@@ -380,7 +380,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=934449" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=934449&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=934449 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/travel-hacks-tips-save-money-time.html
+++ b/articles/travel-hacks-tips-save-money-time.html
@@ -269,7 +269,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=43557" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=43557&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=43557 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/traveling-silk-road.html
+++ b/articles/traveling-silk-road.html
@@ -275,7 +275,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=155275" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=155275&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=155275 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/traveling-through-taste-culinary-journey.html
+++ b/articles/traveling-through-taste-culinary-journey.html
@@ -279,7 +279,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=510052" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=510052&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=510052 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/traveling-through-time-oldest-cities.html
+++ b/articles/traveling-through-time-oldest-cities.html
@@ -291,7 +291,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=188302" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=188302&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=188302 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/traveling-twist-unique-festivals-globe.html
+++ b/articles/traveling-twist-unique-festivals-globe.html
@@ -262,7 +262,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=829988" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=829988&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=829988 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/traveling-without-trace.html
+++ b/articles/traveling-without-trace.html
@@ -285,7 +285,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=399685" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=399685&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=399685 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/ultimate-family-solo-travel-planning-tips-2025.html
+++ b/articles/ultimate-family-solo-travel-planning-tips-2025.html
@@ -326,7 +326,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=740822" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=740822&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=740822 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html
+++ b/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html
@@ -322,7 +322,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=637849" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=637849&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=637849 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/unexpected-journeys-realities-modern-travel-experiences.html
+++ b/articles/unexpected-journeys-realities-modern-travel-experiences.html
@@ -369,7 +369,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=418573" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=418573&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=418573 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html
+++ b/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html
@@ -315,7 +315,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=116661" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=116661&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=116661 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/unforgettable-travel-adventures-inspiring-journeys-world.html
+++ b/articles/unforgettable-travel-adventures-inspiring-journeys-world.html
@@ -324,7 +324,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=124764" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=124764&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=124764 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/unforgettable-travel-experiences-top-destinations-2025.html
+++ b/articles/unforgettable-travel-experiences-top-destinations-2025.html
@@ -382,7 +382,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=488028" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=488028&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=488028 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/unforgettable-travel-journeys-unique-destinations-experiences.html
+++ b/articles/unforgettable-travel-journeys-unique-destinations-experiences.html
@@ -324,7 +324,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=756013" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=756013&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=756013 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html
+++ b/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html
@@ -369,7 +369,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=993696" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=993696&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=993696 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/unplanned-journeys-travel-realities-insights.html
+++ b/articles/unplanned-journeys-travel-realities-insights.html
@@ -340,7 +340,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=902156" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=902156&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=902156 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 </section>

--- a/articles/unplugged-adventures-travel-without-technology.html
+++ b/articles/unplugged-adventures-travel-without-technology.html
@@ -269,7 +269,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=434157" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=434157&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=434157 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/unveiling-magic-polar-expeditions.html
+++ b/articles/unveiling-magic-polar-expeditions.html
@@ -284,7 +284,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=853695" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=853695&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=853695 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/visit-earth-extremities.html
+++ b/articles/visit-earth-extremities.html
@@ -277,7 +277,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=580138" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=580138&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=580138 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/voluntourism-impactful-travel.html
+++ b/articles/voluntourism-impactful-travel.html
@@ -282,7 +282,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=679377" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=679377&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=679377 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 

--- a/articles/voyage-through-vineyards-global-wine-regions.html
+++ b/articles/voyage-through-vineyards-global-wine-regions.html
@@ -276,7 +276,7 @@
     <img src="https://source.unsplash.com/random/200x75?travel&sig=829619" srcset="
         https://source.unsplash.com/random/200x75?travel&sig=829619&dpr=2 400w,
         https://source.unsplash.com/random/200x75?travel&sig=829619 200w
-      " sizes="100vw" alt="Random travel image from Unsplash" decoding="async" width="1080" height="400" title="https://unsplash.com" />
+      " sizes="100vw" alt="Random travel image from Unsplash" loading="lazy" decoding="async" width="1080" height="400" title="https://unsplash.com" />
   </picture>
 </figure>
 


### PR DESCRIPTION
## Summary
- Lazy load second images across all articles to improve page performance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b89be7788329a12ef47d95351b54