### PR TITLE
Fix hero image placement in surfing article

### DIFF
--- a/articles/top-surfing-destinations-world.html
+++ b/articles/top-surfing-destinations-world.html
@@ -199,7 +199,44 @@
           (adsbygoogle = window.adsbygoogle || []).push({});
         </script>
         <figure>
-          
+          <picture>
+            <!-- Desktop: full‑width -->
+            <source
+              media="(min-width:76rem)"
+              srcset="
+                https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=1080&h=400&dpr=2 2160w,
+                https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=1080&h=400 1080w
+              "
+              sizes="(min-width:76rem) 76rem, 100vw"
+            />
+
+            <!-- Tablet -->
+            <source
+              media="(min-width:38rem)"
+              srcset="
+                https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=400&h=150&dpr=2 800w,
+                https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=400&h=150 400w
+              "
+              sizes="(min-width:38rem) 38rem, 100vw"
+            />
+
+            <!-- Mobile fallback -->
+            <img
+              src="https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=200&h=75"
+              srcset="
+                https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=200&h=75&dpr=2 400w,
+                https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=200&h=75 200w
+              "
+              sizes="100vw"
+              alt="aerial photography of seashore"
+              decoding="async"
+              width="1080"
+              height="400"
+              fetchpriority="high"
+              title="https://unsplash.com/photos/aerial-photography-of-seashore-F6XKjhMNB14"
+            />
+          </picture>
+        </figure>
 
           <p>
             Seasons and weather patterns greatly influence the best times to
@@ -274,46 +311,6 @@
             family-friendly and adventure-packed destination for all skill
             levels.
           </p>
-<picture>
-            <!-- Desktop: full‑width -->
-            <source
-              media="(min-width:76rem)"
-              srcset="
-                https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=1080&h=400&dpr=2 2160w,
-                https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=1080&h=400       1080w
-              "
-              sizes="(min-width:76rem) 76rem, 100vw"
-            />
-
-            <!-- Tablet -->
-            <source
-              media="(min-width:38rem)"
-              srcset="
-                https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=400&h=150&dpr=2 800w,
-                https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=400&h=150       400w
-              "
-              sizes="(min-width:38rem) 38rem, 100vw"
-            />
-
-            <!-- Mobile fallback -->
-            <img
-              src="https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=200&h=75"
-              srcset="
-                https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=200&h=75&dpr=2 400w,
-                https://images.unsplash.com/photo-1519229642444-2c6c164c3aa5?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxiZWF1dGlmdWwlMjBzdXJmaW5nJTIwd2F2ZSUyMGNvYXN0bGluZXxlbnwwfHx8fDE3NDUzMzU0MzZ8MA&ixlib=rb-4.0.3&q=80&w=200&h=75       200w
-              "
-              sizes="100vw"
-              alt="aerial photography of seashore"
-              decoding="async"
-              width="1080"
-              height="400"
-              fetchpriority="high"
-              title="https://unsplash.com/photos/aerial-photography-of-seashore-F6XKjhMNB14"
-            />
-          </picture>
-        </figure>
-        
-        
         </section><section>
           <h2>Understanding the Surfing Landscape around the Globe</h2>
           <p>


### PR DESCRIPTION
## Summary
- Position hero image directly below article introduction in the surfing destinations article
- Remove stray figure wrapper and duplicate image block

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b30bbcb628832994991fff7a89a5cc