### PR TITLE
Shorten Picsum image slugs

### DIFF
--- a/articles/african-safari-experience-a-journey-into-the-wild.html
+++ b/articles/african-safari-experience-a-journey-into-the-wild.html
@@ -308,27 +308,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/african-safari-experience-a-journey-into-the-wild/1080/400.webp"
+              srcset="https://picsum.photos/seed/african-safari-experience-a-0280dc/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/african-safari-experience-a-journey-into-the-wild/1080/400.jpg"
+              srcset="https://picsum.photos/seed/african-safari-experience-a-0280dc/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/african-safari-experience-a-journey-into-the-wild/800/300.webp"
+              srcset="https://picsum.photos/seed/african-safari-experience-a-0280dc/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/african-safari-experience-a-journey-into-the-wild/800/300.jpg"
+              srcset="https://picsum.photos/seed/african-safari-experience-a-0280dc/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/african-safari-experience-a-journey-into-the-wild/400/200.jpg"
+              src="https://picsum.photos/seed/african-safari-experience-a-0280dc/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/architectural-marvels-modern-wonders-world.html
+++ b/articles/architectural-marvels-modern-wonders-world.html
@@ -329,13 +329,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/architectural-marvels-modern-wonders-world/1080/400.webp
+                  https://picsum.photos/seed/architectural-marvels-modern-wonders-81e958/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/architectural-marvels-modern-wonders-world/1080/400.jpg
+                  https://picsum.photos/seed/architectural-marvels-modern-wonders-81e958/1080/400.jpg
                 "
               />
 
@@ -344,19 +344,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/architectural-marvels-modern-wonders-world/800/300.webp
+                  https://picsum.photos/seed/architectural-marvels-modern-wonders-81e958/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/architectural-marvels-modern-wonders-world/800/300.jpg
+                  https://picsum.photos/seed/architectural-marvels-modern-wonders-81e958/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/architectural-marvels-modern-wonders-world/400/200.jpg"
+                src="https://picsum.photos/seed/architectural-marvels-modern-wonders-81e958/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/behind-scenes-worlds-largest-festivals.html
+++ b/articles/behind-scenes-worlds-largest-festivals.html
@@ -333,13 +333,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/behind-scenes-worlds-largest-festivals/1080/400.webp
+                  https://picsum.photos/seed/behind-scenes-worlds-largest-6558b2/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/behind-scenes-worlds-largest-festivals/1080/400.jpg
+                  https://picsum.photos/seed/behind-scenes-worlds-largest-6558b2/1080/400.jpg
                 "
               />
 
@@ -348,19 +348,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/behind-scenes-worlds-largest-festivals/800/300.webp
+                  https://picsum.photos/seed/behind-scenes-worlds-largest-6558b2/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/behind-scenes-worlds-largest-festivals/800/300.jpg
+                  https://picsum.photos/seed/behind-scenes-worlds-largest-6558b2/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/behind-scenes-worlds-largest-festivals/400/200.jpg"
+                src="https://picsum.photos/seed/behind-scenes-worlds-largest-6558b2/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/best-safari-destinations.html
+++ b/articles/best-safari-destinations.html
@@ -321,13 +321,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/best-safari-destinations/1080/400.webp
+                  https://picsum.photos/seed/best-safari-destinations-d06620/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/best-safari-destinations/1080/400.jpg
+                  https://picsum.photos/seed/best-safari-destinations-d06620/1080/400.jpg
                 "
               />
 
@@ -336,19 +336,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/best-safari-destinations/800/300.webp
+                  https://picsum.photos/seed/best-safari-destinations-d06620/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/best-safari-destinations/800/300.jpg
+                  https://picsum.photos/seed/best-safari-destinations-d06620/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/best-safari-destinations/400/200.jpg"
+                src="https://picsum.photos/seed/best-safari-destinations-d06620/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/best-travel-apps.html
+++ b/articles/best-travel-apps.html
@@ -306,27 +306,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/best-travel-apps/1080/400.webp"
+              srcset="https://picsum.photos/seed/best-travel-apps-ee5a97/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/best-travel-apps/1080/400.jpg"
+              srcset="https://picsum.photos/seed/best-travel-apps-ee5a97/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/best-travel-apps/800/300.webp"
+              srcset="https://picsum.photos/seed/best-travel-apps-ee5a97/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/best-travel-apps/800/300.jpg"
+              srcset="https://picsum.photos/seed/best-travel-apps-ee5a97/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/best-travel-apps/400/200.jpg"
+              src="https://picsum.photos/seed/best-travel-apps-ee5a97/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/beyond-hostels-hotels-unique-accommodations-adventurous-traveler.html
+++ b/articles/beyond-hostels-hotels-unique-accommodations-adventurous-traveler.html
@@ -306,27 +306,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/beyond-hostels-hotels-unique-accommodations-adventurous-traveler/1080/400.webp"
+              srcset="https://picsum.photos/seed/beyond-hostels-hotels-unique-1fdfdd/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/beyond-hostels-hotels-unique-accommodations-adventurous-traveler/1080/400.jpg"
+              srcset="https://picsum.photos/seed/beyond-hostels-hotels-unique-1fdfdd/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/beyond-hostels-hotels-unique-accommodations-adventurous-traveler/800/300.webp"
+              srcset="https://picsum.photos/seed/beyond-hostels-hotels-unique-1fdfdd/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/beyond-hostels-hotels-unique-accommodations-adventurous-traveler/800/300.jpg"
+              srcset="https://picsum.photos/seed/beyond-hostels-hotels-unique-1fdfdd/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/beyond-hostels-hotels-unique-accommodations-adventurous-traveler/400/200.jpg"
+              src="https://picsum.photos/seed/beyond-hostels-hotels-unique-1fdfdd/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/chasing-northern-lights-best-places.html
+++ b/articles/chasing-northern-lights-best-places.html
@@ -336,27 +336,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/chasing-northern-lights-best-places/1080/400.webp"
+              srcset="https://picsum.photos/seed/chasing-northern-lights-best-a317f3/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/chasing-northern-lights-best-places/1080/400.jpg"
+              srcset="https://picsum.photos/seed/chasing-northern-lights-best-a317f3/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/chasing-northern-lights-best-places/800/300.webp"
+              srcset="https://picsum.photos/seed/chasing-northern-lights-best-a317f3/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/chasing-northern-lights-best-places/800/300.jpg"
+              srcset="https://picsum.photos/seed/chasing-northern-lights-best-a317f3/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/chasing-northern-lights-best-places/400/200.jpg"
+              src="https://picsum.photos/seed/chasing-northern-lights-best-a317f3/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/culinary-trails-origins-iconic-street-food.html
+++ b/articles/culinary-trails-origins-iconic-street-food.html
@@ -324,13 +324,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/culinary-trails-origins-iconic-street-food/1080/400.webp
+                  https://picsum.photos/seed/culinary-trails-origins-iconic-b9f2f2/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/culinary-trails-origins-iconic-street-food/1080/400.jpg
+                  https://picsum.photos/seed/culinary-trails-origins-iconic-b9f2f2/1080/400.jpg
                 "
               />
 
@@ -339,19 +339,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/culinary-trails-origins-iconic-street-food/800/300.webp
+                  https://picsum.photos/seed/culinary-trails-origins-iconic-b9f2f2/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/culinary-trails-origins-iconic-street-food/800/300.jpg
+                  https://picsum.photos/seed/culinary-trails-origins-iconic-b9f2f2/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/culinary-trails-origins-iconic-street-food/400/200.jpg"
+                src="https://picsum.photos/seed/culinary-trails-origins-iconic-b9f2f2/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/cultural-immersion-experiences.html
+++ b/articles/cultural-immersion-experiences.html
@@ -314,27 +314,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/cultural-immersion-experiences/1080/400.webp"
+              srcset="https://picsum.photos/seed/cultural-immersion-experiences-66e895/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/cultural-immersion-experiences/1080/400.jpg"
+              srcset="https://picsum.photos/seed/cultural-immersion-experiences-66e895/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/cultural-immersion-experiences/800/300.webp"
+              srcset="https://picsum.photos/seed/cultural-immersion-experiences-66e895/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/cultural-immersion-experiences/800/300.jpg"
+              srcset="https://picsum.photos/seed/cultural-immersion-experiences-66e895/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/cultural-immersion-experiences/400/200.jpg"
+              src="https://picsum.photos/seed/cultural-immersion-experiences-66e895/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/dark-tourism-worlds-haunting-locations.html
+++ b/articles/dark-tourism-worlds-haunting-locations.html
@@ -308,27 +308,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/dark-tourism-worlds-haunting-locations/1080/400.webp"
+              srcset="https://picsum.photos/seed/dark-tourism-worlds-haunting-73cfb6/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/dark-tourism-worlds-haunting-locations/1080/400.jpg"
+              srcset="https://picsum.photos/seed/dark-tourism-worlds-haunting-73cfb6/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/dark-tourism-worlds-haunting-locations/800/300.webp"
+              srcset="https://picsum.photos/seed/dark-tourism-worlds-haunting-73cfb6/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/dark-tourism-worlds-haunting-locations/800/300.jpg"
+              srcset="https://picsum.photos/seed/dark-tourism-worlds-haunting-73cfb6/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/dark-tourism-worlds-haunting-locations/400/200.jpg"
+              src="https://picsum.photos/seed/dark-tourism-worlds-haunting-73cfb6/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/digital-nomad-life-world.html
+++ b/articles/digital-nomad-life-world.html
@@ -359,13 +359,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/digital-nomad-life-world/1080/400.webp
+                  https://picsum.photos/seed/digital-nomad-life-world-51be74/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/digital-nomad-life-world/1080/400.jpg
+                  https://picsum.photos/seed/digital-nomad-life-world-51be74/1080/400.jpg
                 "
               />
 
@@ -374,19 +374,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/digital-nomad-life-world/800/300.webp
+                  https://picsum.photos/seed/digital-nomad-life-world-51be74/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/digital-nomad-life-world/800/300.jpg
+                  https://picsum.photos/seed/digital-nomad-life-world-51be74/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/digital-nomad-life-world/400/200.jpg"
+                src="https://picsum.photos/seed/digital-nomad-life-world-51be74/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/discover-transformative-travel-stories-trending-destinations.html
+++ b/articles/discover-transformative-travel-stories-trending-destinations.html
@@ -300,13 +300,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/discover-transformative-travel-stories-top-trending-destinations/1080/400.webp
+                  https://picsum.photos/seed/discover-transformative-travel-stories-5819e1/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/discover-transformative-travel-stories-top-trending-destinations/1080/400.jpg
+                  https://picsum.photos/seed/discover-transformative-travel-stories-5819e1/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -314,18 +314,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/discover-transformative-travel-stories-top-trending-destinations/800/300.webp
+                  https://picsum.photos/seed/discover-transformative-travel-stories-5819e1/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/discover-transformative-travel-stories-top-trending-destinations/800/300.jpg
+                  https://picsum.photos/seed/discover-transformative-travel-stories-5819e1/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/discover-transformative-travel-stories-top-trending-destinations/480/240.jpg"
+                src="https://picsum.photos/seed/discover-transformative-travel-stories-5819e1/480/240.jpg"
                 alt="Rooftops and riverfront of a European old town at golden hour with markets below"
                 width="1080"
                 height="400"
@@ -438,13 +438,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/discover-transformative-travel-stories-trending-destinations/1080/400.webp
+                  https://picsum.photos/seed/discover-transformative-travel-stories-d81a4b/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/discover-transformative-travel-stories-trending-destinations/1080/400.jpg
+                  https://picsum.photos/seed/discover-transformative-travel-stories-d81a4b/1080/400.jpg
                 "
               />
 
@@ -453,19 +453,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/discover-transformative-travel-stories-trending-destinations/800/300.webp
+                  https://picsum.photos/seed/discover-transformative-travel-stories-d81a4b/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/discover-transformative-travel-stories-trending-destinations/800/300.jpg
+                  https://picsum.photos/seed/discover-transformative-travel-stories-d81a4b/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/discover-transformative-travel-stories-trending-destinations/400/200.jpg"
+                src="https://picsum.photos/seed/discover-transformative-travel-stories-d81a4b/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/discovering-underwater-world-best-snorkeling-spots-globally.html
+++ b/articles/discovering-underwater-world-best-snorkeling-spots-globally.html
@@ -310,27 +310,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/discovering-underwater-world-best-snorkeling-spots-globally/1080/400.webp"
+              srcset="https://picsum.photos/seed/discovering-underwater-world-best-6e5173/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/discovering-underwater-world-best-snorkeling-spots-globally/1080/400.jpg"
+              srcset="https://picsum.photos/seed/discovering-underwater-world-best-6e5173/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/discovering-underwater-world-best-snorkeling-spots-globally/800/300.webp"
+              srcset="https://picsum.photos/seed/discovering-underwater-world-best-6e5173/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/discovering-underwater-world-best-snorkeling-spots-globally/800/300.jpg"
+              srcset="https://picsum.photos/seed/discovering-underwater-world-best-6e5173/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/discovering-underwater-world-best-snorkeling-spots-globally/400/200.jpg"
+              src="https://picsum.photos/seed/discovering-underwater-world-best-6e5173/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/eco-friendly-traveling-world-sustainably.html
+++ b/articles/eco-friendly-traveling-world-sustainably.html
@@ -395,13 +395,13 @@
         <figure>
           <picture>
             <!-- Desktop -->
-            <source type="image/webp" media="(min-width:76rem)" srcset="https://picsum.photos/seed/eco-friendly-traveling-world-sustainably/1080/400.webp" />
-            <source media="(min-width:76rem)" srcset="https://picsum.photos/seed/eco-friendly-traveling-world-sustainably/1080/400.jpg" />
+            <source type="image/webp" media="(min-width:76rem)" srcset="https://picsum.photos/seed/eco-friendly-traveling-world-88a03b/1080/400.webp" />
+            <source media="(min-width:76rem)" srcset="https://picsum.photos/seed/eco-friendly-traveling-world-88a03b/1080/400.jpg" />
             <!-- Tablet -->
-            <source type="image/webp" media="(min-width:38rem)" srcset="https://picsum.photos/seed/eco-friendly-traveling-world-sustainably/800/300.webp" />
-            <source media="(min-width:38rem)" srcset="https://picsum.photos/seed/eco-friendly-traveling-world-sustainably/800/300.jpg" />
+            <source type="image/webp" media="(min-width:38rem)" srcset="https://picsum.photos/seed/eco-friendly-traveling-world-88a03b/800/300.webp" />
+            <source media="(min-width:38rem)" srcset="https://picsum.photos/seed/eco-friendly-traveling-world-88a03b/800/300.jpg" />
             <!-- Mobile Fallback -->
-            <img src="https://picsum.photos/seed/eco-friendly-traveling-world-sustainably/400/200.jpg" alt="Random placeholder photo" title="Photo via https://picsum.photos" width="1080" height="400" loading="lazy" decoding="async" />
+            <img src="https://picsum.photos/seed/eco-friendly-traveling-world-88a03b/400/200.jpg" alt="Random placeholder photo" title="Photo via https://picsum.photos" width="1080" height="400" loading="lazy" decoding="async" />
           </picture>
         </figure>
 </article>

--- a/articles/embracing-eco-tourism-sustainable-journey-costa-rica.html
+++ b/articles/embracing-eco-tourism-sustainable-journey-costa-rica.html
@@ -308,27 +308,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/embracing-eco-tourism-sustainable-journey-costa-rica/1080/400.webp"
+              srcset="https://picsum.photos/seed/embracing-eco-tourism-sustainable-434631/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/embracing-eco-tourism-sustainable-journey-costa-rica/1080/400.jpg"
+              srcset="https://picsum.photos/seed/embracing-eco-tourism-sustainable-434631/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/embracing-eco-tourism-sustainable-journey-costa-rica/800/300.webp"
+              srcset="https://picsum.photos/seed/embracing-eco-tourism-sustainable-434631/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/embracing-eco-tourism-sustainable-journey-costa-rica/800/300.jpg"
+              srcset="https://picsum.photos/seed/embracing-eco-tourism-sustainable-434631/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/embracing-eco-tourism-sustainable-journey-costa-rica/400/200.jpg"
+              src="https://picsum.photos/seed/embracing-eco-tourism-sustainable-434631/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/explore-enchanting-destinations-smart-travel-planning-2025.html
+++ b/articles/explore-enchanting-destinations-smart-travel-planning-2025.html
@@ -371,27 +371,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/explore-enchanting-destinations-smart-travel-planning-2025/1080/400.webp"
+              srcset="https://picsum.photos/seed/explore-enchanting-destinations-smart-9ca380/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/explore-enchanting-destinations-smart-travel-planning-2025/1080/400.jpg"
+              srcset="https://picsum.photos/seed/explore-enchanting-destinations-smart-9ca380/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/explore-enchanting-destinations-smart-travel-planning-2025/800/300.webp"
+              srcset="https://picsum.photos/seed/explore-enchanting-destinations-smart-9ca380/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/explore-enchanting-destinations-smart-travel-planning-2025/800/300.jpg"
+              srcset="https://picsum.photos/seed/explore-enchanting-destinations-smart-9ca380/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/explore-enchanting-destinations-smart-travel-planning-2025/400/200.jpg"
+              src="https://picsum.photos/seed/explore-enchanting-destinations-smart-9ca380/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/explore-unique-travel-experiences-hidden-gems-2025.html
+++ b/articles/explore-unique-travel-experiences-hidden-gems-2025.html
@@ -263,13 +263,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/explore-unique-travel-experiences-hidden-gems-2025/1080/400.webp
+                  https://picsum.photos/seed/explore-unique-travel-experiences-623d57/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/explore-unique-travel-experiences-hidden-gems-2025/1080/400.jpg
+                  https://picsum.photos/seed/explore-unique-travel-experiences-623d57/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -277,18 +277,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/explore-unique-travel-experiences-hidden-gems-2025/800/300.webp
+                  https://picsum.photos/seed/explore-unique-travel-experiences-623d57/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/explore-unique-travel-experiences-hidden-gems-2025/800/300.jpg
+                  https://picsum.photos/seed/explore-unique-travel-experiences-623d57/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/explore-unique-travel-experiences-hidden-gems-2025/480/240.jpg"
+                src="https://picsum.photos/seed/explore-unique-travel-experiences-623d57/480/240.jpg"
                 alt="Quiet side street with small cafés and workshops that hint at hidden local gems"
                 width="1080"
                 height="400"
@@ -460,13 +460,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/explore-unique-travel-experiences-hidden-gems-2025/1080/400.webp
+                  https://picsum.photos/seed/explore-unique-travel-experiences-623d57/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/explore-unique-travel-experiences-hidden-gems-2025/1080/400.jpg
+                  https://picsum.photos/seed/explore-unique-travel-experiences-623d57/1080/400.jpg
                 "
               />
 
@@ -475,19 +475,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/explore-unique-travel-experiences-hidden-gems-2025/800/300.webp
+                  https://picsum.photos/seed/explore-unique-travel-experiences-623d57/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/explore-unique-travel-experiences-hidden-gems-2025/800/300.jpg
+                  https://picsum.photos/seed/explore-unique-travel-experiences-623d57/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/explore-unique-travel-experiences-hidden-gems-2025/400/200.jpg"
+                src="https://picsum.photos/seed/explore-unique-travel-experiences-623d57/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/exploring-arctic-travel-guide.html
+++ b/articles/exploring-arctic-travel-guide.html
@@ -326,27 +326,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/exploring-arctic-travel-guide/1080/400.webp"
+              srcset="https://picsum.photos/seed/exploring-arctic-travel-guide-8688a2/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/exploring-arctic-travel-guide/1080/400.jpg"
+              srcset="https://picsum.photos/seed/exploring-arctic-travel-guide-8688a2/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/exploring-arctic-travel-guide/800/300.webp"
+              srcset="https://picsum.photos/seed/exploring-arctic-travel-guide-8688a2/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/exploring-arctic-travel-guide/800/300.jpg"
+              srcset="https://picsum.photos/seed/exploring-arctic-travel-guide-8688a2/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/exploring-arctic-travel-guide/400/200.jpg"
+              src="https://picsum.photos/seed/exploring-arctic-travel-guide-8688a2/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/exploring-authentic-travel-experiences-hidden-gems-challenges.html
+++ b/articles/exploring-authentic-travel-experiences-hidden-gems-challenges.html
@@ -267,13 +267,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-authentic-travel-experiences-from-hidden-gems-to-real-challenges/1080/400.webp
+                  https://picsum.photos/seed/exploring-authentic-travel-experiences-de3b82/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-authentic-travel-experiences-from-hidden-gems-to-real-challenges/1080/400.jpg
+                  https://picsum.photos/seed/exploring-authentic-travel-experiences-de3b82/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -281,18 +281,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-authentic-travel-experiences-from-hidden-gems-to-real-challenges/800/300.webp
+                  https://picsum.photos/seed/exploring-authentic-travel-experiences-de3b82/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-authentic-travel-experiences-from-hidden-gems-to-real-challenges/800/300.jpg
+                  https://picsum.photos/seed/exploring-authentic-travel-experiences-de3b82/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/exploring-authentic-travel-experiences-from-hidden-gems-to-real-challenges/480/240.jpg"
+                src="https://picsum.photos/seed/exploring-authentic-travel-experiences-de3b82/480/240.jpg"
                 alt="Early-morning neighborhood street with small cafés opening and locals walking"
                 width="1080"
                 height="400"
@@ -455,13 +455,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-authentic-travel-experiences-hidden-gems-challenges/1080/400.webp
+                  https://picsum.photos/seed/exploring-authentic-travel-experiences-8fe468/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-authentic-travel-experiences-hidden-gems-challenges/1080/400.jpg
+                  https://picsum.photos/seed/exploring-authentic-travel-experiences-8fe468/1080/400.jpg
                 "
               />
 
@@ -470,19 +470,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-authentic-travel-experiences-hidden-gems-challenges/800/300.webp
+                  https://picsum.photos/seed/exploring-authentic-travel-experiences-8fe468/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-authentic-travel-experiences-hidden-gems-challenges/800/300.jpg
+                  https://picsum.photos/seed/exploring-authentic-travel-experiences-8fe468/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/exploring-authentic-travel-experiences-hidden-gems-challenges/400/200.jpg"
+                src="https://picsum.photos/seed/exploring-authentic-travel-experiences-8fe468/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/exploring-emerging-travel-trends-and-unique-hobby-inspirations.html
+++ b/articles/exploring-emerging-travel-trends-and-unique-hobby-inspirations.html
@@ -359,27 +359,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/exploring-emerging-travel-trends-and-unique-hobby-inspirations/1080/400.webp"
+              srcset="https://picsum.photos/seed/exploring-emerging-travel-trends-38fb98/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/exploring-emerging-travel-trends-and-unique-hobby-inspirations/1080/400.jpg"
+              srcset="https://picsum.photos/seed/exploring-emerging-travel-trends-38fb98/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/exploring-emerging-travel-trends-and-unique-hobby-inspirations/800/300.webp"
+              srcset="https://picsum.photos/seed/exploring-emerging-travel-trends-38fb98/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/exploring-emerging-travel-trends-and-unique-hobby-inspirations/800/300.jpg"
+              srcset="https://picsum.photos/seed/exploring-emerging-travel-trends-38fb98/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/exploring-emerging-travel-trends-and-unique-hobby-inspirations/400/200.jpg"
+              src="https://picsum.photos/seed/exploring-emerging-travel-trends-38fb98/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/exploring-emerging-travel-trends-unique-hobby-inspirations.html
+++ b/articles/exploring-emerging-travel-trends-unique-hobby-inspirations.html
@@ -269,13 +269,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/emerging-travel-trends-unique-hobby-inspirations/1080/400.webp
+                  https://picsum.photos/seed/emerging-travel-trends-unique-d453f0/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/emerging-travel-trends-unique-hobby-inspirations/1080/400.jpg
+                  https://picsum.photos/seed/emerging-travel-trends-unique-d453f0/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -283,18 +283,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/emerging-travel-trends-unique-hobby-inspirations/800/300.webp
+                  https://picsum.photos/seed/emerging-travel-trends-unique-d453f0/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/emerging-travel-trends-unique-hobby-inspirations/800/300.jpg
+                  https://picsum.photos/seed/emerging-travel-trends-unique-d453f0/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/emerging-travel-trends-unique-hobby-inspirations/480/240.jpg"
+                src="https://picsum.photos/seed/emerging-travel-trends-unique-d453f0/480/240.jpg"
                 alt="Quiet neighborhood market street in the early morning light"
                 width="1080"
                 height="400"
@@ -477,13 +477,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-emerging-travel-trends-unique-hobby-inspirations/1080/400.webp
+                  https://picsum.photos/seed/exploring-emerging-travel-trends-de2a61/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-emerging-travel-trends-unique-hobby-inspirations/1080/400.jpg
+                  https://picsum.photos/seed/exploring-emerging-travel-trends-de2a61/1080/400.jpg
                 "
               />
 
@@ -492,19 +492,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-emerging-travel-trends-unique-hobby-inspirations/800/300.webp
+                  https://picsum.photos/seed/exploring-emerging-travel-trends-de2a61/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-emerging-travel-trends-unique-hobby-inspirations/800/300.jpg
+                  https://picsum.photos/seed/exploring-emerging-travel-trends-de2a61/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/exploring-emerging-travel-trends-unique-hobby-inspirations/400/200.jpg"
+                src="https://picsum.photos/seed/exploring-emerging-travel-trends-de2a61/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/exploring-new-horizons-top-travel-tips-destinations-2025.html
+++ b/articles/exploring-new-horizons-top-travel-tips-destinations-2025.html
@@ -270,13 +270,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-new-horizons-top-travel-tips-and-destinations-2025/1080/400.webp
+                  https://picsum.photos/seed/exploring-new-horizons-top-e2c718/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-new-horizons-top-travel-tips-and-destinations-2025/1080/400.jpg
+                  https://picsum.photos/seed/exploring-new-horizons-top-e2c718/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -284,18 +284,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-new-horizons-top-travel-tips-and-destinations-2025/800/300.webp
+                  https://picsum.photos/seed/exploring-new-horizons-top-e2c718/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-new-horizons-top-travel-tips-and-destinations-2025/800/300.jpg
+                  https://picsum.photos/seed/exploring-new-horizons-top-e2c718/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/exploring-new-horizons-top-travel-tips-and-destinations-2025/480/240.jpg"
+                src="https://picsum.photos/seed/exploring-new-horizons-top-e2c718/480/240.jpg"
                 alt="Traveler reviewing an offline map and tickets before boarding a train"
                 width="1080"
                 height="400"
@@ -484,13 +484,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-new-horizons-top-travel-tips-destinations-2025/1080/400.webp
+                  https://picsum.photos/seed/exploring-new-horizons-top-23f3b1/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-new-horizons-top-travel-tips-destinations-2025/1080/400.jpg
+                  https://picsum.photos/seed/exploring-new-horizons-top-23f3b1/1080/400.jpg
                 "
               />
 
@@ -499,19 +499,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-new-horizons-top-travel-tips-destinations-2025/800/300.webp
+                  https://picsum.photos/seed/exploring-new-horizons-top-23f3b1/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-new-horizons-top-travel-tips-destinations-2025/800/300.jpg
+                  https://picsum.photos/seed/exploring-new-horizons-top-23f3b1/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/exploring-new-horizons-top-travel-tips-destinations-2025/400/200.jpg"
+                src="https://picsum.photos/seed/exploring-new-horizons-top-23f3b1/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/exploring-scottish-highlands.html
+++ b/articles/exploring-scottish-highlands.html
@@ -331,13 +331,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-scottish-highlands/1080/400.webp
+                  https://picsum.photos/seed/exploring-scottish-highlands-73365f/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-scottish-highlands/1080/400.jpg
+                  https://picsum.photos/seed/exploring-scottish-highlands-73365f/1080/400.jpg
                 "
               />
 
@@ -346,19 +346,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-scottish-highlands/800/300.webp
+                  https://picsum.photos/seed/exploring-scottish-highlands-73365f/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-scottish-highlands/800/300.jpg
+                  https://picsum.photos/seed/exploring-scottish-highlands-73365f/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/exploring-scottish-highlands/400/200.jpg"
+                src="https://picsum.photos/seed/exploring-scottish-highlands-73365f/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/exploring-trending-travel-destinations-and-relaxing-hobby-ideas.html
+++ b/articles/exploring-trending-travel-destinations-and-relaxing-hobby-ideas.html
@@ -273,13 +273,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/trending-travel-destinations-relaxing-hobby-ideas-2025/1080/400.webp
+                  https://picsum.photos/seed/trending-travel-destinations-relaxing-79c0c6/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/trending-travel-destinations-relaxing-hobby-ideas-2025/1080/400.jpg
+                  https://picsum.photos/seed/trending-travel-destinations-relaxing-79c0c6/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -287,18 +287,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/trending-travel-destinations-relaxing-hobby-ideas-2025/800/300.webp
+                  https://picsum.photos/seed/trending-travel-destinations-relaxing-79c0c6/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/trending-travel-destinations-relaxing-hobby-ideas-2025/800/300.jpg
+                  https://picsum.photos/seed/trending-travel-destinations-relaxing-79c0c6/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/trending-travel-destinations-relaxing-hobby-ideas-2025/480/240.jpg"
+                src="https://picsum.photos/seed/trending-travel-destinations-relaxing-79c0c6/480/240.jpg"
                 alt="Terraced hills above a river valley at golden hour, with a small village in the distance"
                 width="1080"
                 height="400"
@@ -470,13 +470,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-trending-travel-destinations-and-relaxing-hobby-ideas/1080/400.webp
+                  https://picsum.photos/seed/exploring-trending-travel-destinations-499701/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-trending-travel-destinations-and-relaxing-hobby-ideas/1080/400.jpg
+                  https://picsum.photos/seed/exploring-trending-travel-destinations-499701/1080/400.jpg
                 "
               />
 
@@ -485,19 +485,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-trending-travel-destinations-and-relaxing-hobby-ideas/800/300.webp
+                  https://picsum.photos/seed/exploring-trending-travel-destinations-499701/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-trending-travel-destinations-and-relaxing-hobby-ideas/800/300.jpg
+                  https://picsum.photos/seed/exploring-trending-travel-destinations-499701/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/exploring-trending-travel-destinations-and-relaxing-hobby-ideas/400/200.jpg"
+                src="https://picsum.photos/seed/exploring-trending-travel-destinations-499701/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/exploring-unesco-sites.html
+++ b/articles/exploring-unesco-sites.html
@@ -318,13 +318,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-unesco-sites/1080/400.webp
+                  https://picsum.photos/seed/exploring-unesco-sites-d78b8e/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-unesco-sites/1080/400.jpg
+                  https://picsum.photos/seed/exploring-unesco-sites-d78b8e/1080/400.jpg
                 "
               />
 
@@ -333,19 +333,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-unesco-sites/800/300.webp
+                  https://picsum.photos/seed/exploring-unesco-sites-d78b8e/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-unesco-sites/800/300.jpg
+                  https://picsum.photos/seed/exploring-unesco-sites-d78b8e/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/exploring-unesco-sites/400/200.jpg"
+                src="https://picsum.photos/seed/exploring-unesco-sites-d78b8e/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/exploring-unique-destinations-travel-experiences-2025.html
+++ b/articles/exploring-unique-destinations-travel-experiences-2025.html
@@ -266,13 +266,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unique-destinations-travel-experiences-worldwide-2025/1080/400.webp
+                  https://picsum.photos/seed/unique-destinations-travel-experiences-fc5a09/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unique-destinations-travel-experiences-worldwide-2025/1080/400.jpg
+                  https://picsum.photos/seed/unique-destinations-travel-experiences-fc5a09/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -280,18 +280,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unique-destinations-travel-experiences-worldwide-2025/800/300.webp
+                  https://picsum.photos/seed/unique-destinations-travel-experiences-fc5a09/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unique-destinations-travel-experiences-worldwide-2025/800/300.jpg
+                  https://picsum.photos/seed/unique-destinations-travel-experiences-fc5a09/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/unique-destinations-travel-experiences-worldwide-2025/480/240.jpg"
+                src="https://picsum.photos/seed/unique-destinations-travel-experiences-fc5a09/480/240.jpg"
                 alt="Traveler sharing tea with a local host in a quiet neighborhood courtyard"
                 width="1080"
                 height="400"
@@ -449,13 +449,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-unique-destinations-travel-experiences-2025/1080/400.webp
+                  https://picsum.photos/seed/exploring-unique-destinations-travel-b2a61d/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-unique-destinations-travel-experiences-2025/1080/400.jpg
+                  https://picsum.photos/seed/exploring-unique-destinations-travel-b2a61d/1080/400.jpg
                 "
               />
 
@@ -464,19 +464,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-unique-destinations-travel-experiences-2025/800/300.webp
+                  https://picsum.photos/seed/exploring-unique-destinations-travel-b2a61d/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-unique-destinations-travel-experiences-2025/800/300.jpg
+                  https://picsum.photos/seed/exploring-unique-destinations-travel-b2a61d/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/exploring-unique-destinations-travel-experiences-2025/400/200.jpg"
+                src="https://picsum.photos/seed/exploring-unique-destinations-travel-b2a61d/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/exploring-untouched-forests.html
+++ b/articles/exploring-untouched-forests.html
@@ -330,13 +330,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-untouched-forests/1080/400.webp
+                  https://picsum.photos/seed/exploring-untouched-forests-ef0a88/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-untouched-forests/1080/400.jpg
+                  https://picsum.photos/seed/exploring-untouched-forests-ef0a88/1080/400.jpg
                 "
               />
 
@@ -345,19 +345,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-untouched-forests/800/300.webp
+                  https://picsum.photos/seed/exploring-untouched-forests-ef0a88/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-untouched-forests/800/300.jpg
+                  https://picsum.photos/seed/exploring-untouched-forests-ef0a88/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/exploring-untouched-forests/400/200.jpg"
+                src="https://picsum.photos/seed/exploring-untouched-forests-ef0a88/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/exploring-worlds-historical-walking-routes.html
+++ b/articles/exploring-worlds-historical-walking-routes.html
@@ -317,13 +317,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-worlds-historical-walking-routes/1080/400.webp
+                  https://picsum.photos/seed/exploring-worlds-historical-walking-217b1f/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-worlds-historical-walking-routes/1080/400.jpg
+                  https://picsum.photos/seed/exploring-worlds-historical-walking-217b1f/1080/400.jpg
                 "
               />
 
@@ -332,19 +332,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-worlds-historical-walking-routes/800/300.webp
+                  https://picsum.photos/seed/exploring-worlds-historical-walking-217b1f/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-worlds-historical-walking-routes/800/300.jpg
+                  https://picsum.photos/seed/exploring-worlds-historical-walking-217b1f/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/exploring-worlds-historical-walking-routes/400/200.jpg"
+                src="https://picsum.photos/seed/exploring-worlds-historical-walking-217b1f/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/exploring-worlds-most-religious-sites.html
+++ b/articles/exploring-worlds-most-religious-sites.html
@@ -320,13 +320,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-worlds-most-religious-sites/1080/400.webp
+                  https://picsum.photos/seed/exploring-worlds-most-religious-0d5cf6/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-worlds-most-religious-sites/1080/400.jpg
+                  https://picsum.photos/seed/exploring-worlds-most-religious-0d5cf6/1080/400.jpg
                 "
               />
 
@@ -335,19 +335,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-worlds-most-religious-sites/800/300.webp
+                  https://picsum.photos/seed/exploring-worlds-most-religious-0d5cf6/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-worlds-most-religious-sites/800/300.jpg
+                  https://picsum.photos/seed/exploring-worlds-most-religious-0d5cf6/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/exploring-worlds-most-religious-sites/400/200.jpg"
+                src="https://picsum.photos/seed/exploring-worlds-most-religious-0d5cf6/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/glamping-world-luxury-tents-incredible-views.html
+++ b/articles/glamping-world-luxury-tents-incredible-views.html
@@ -314,13 +314,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/glamping-world-luxury-tents-incredible-views/1080/400.webp
+                  https://picsum.photos/seed/glamping-world-luxury-tents-8dff90/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/glamping-world-luxury-tents-incredible-views/1080/400.jpg
+                  https://picsum.photos/seed/glamping-world-luxury-tents-8dff90/1080/400.jpg
                 "
               />
 
@@ -329,19 +329,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/glamping-world-luxury-tents-incredible-views/800/300.webp
+                  https://picsum.photos/seed/glamping-world-luxury-tents-8dff90/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/glamping-world-luxury-tents-incredible-views/800/300.jpg
+                  https://picsum.photos/seed/glamping-world-luxury-tents-8dff90/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/glamping-world-luxury-tents-incredible-views/400/200.jpg"
+                src="https://picsum.photos/seed/glamping-world-luxury-tents-8dff90/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/global-gastronomy-tasting-traditional-dishes-different-cultures.html
+++ b/articles/global-gastronomy-tasting-traditional-dishes-different-cultures.html
@@ -321,13 +321,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/global-gastronomy-tasting-traditional-dishes-different-cultures/1080/400.webp
+                  https://picsum.photos/seed/global-gastronomy-tasting-traditional-1e5e60/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/global-gastronomy-tasting-traditional-dishes-different-cultures/1080/400.jpg
+                  https://picsum.photos/seed/global-gastronomy-tasting-traditional-1e5e60/1080/400.jpg
                 "
               />
 
@@ -336,19 +336,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/global-gastronomy-tasting-traditional-dishes-different-cultures/800/300.webp
+                  https://picsum.photos/seed/global-gastronomy-tasting-traditional-1e5e60/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/global-gastronomy-tasting-traditional-dishes-different-cultures/800/300.jpg
+                  https://picsum.photos/seed/global-gastronomy-tasting-traditional-1e5e60/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/global-gastronomy-tasting-traditional-dishes-different-cultures/400/200.jpg"
+                src="https://picsum.photos/seed/global-gastronomy-tasting-traditional-1e5e60/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/going-green-vegan-vegetarian-travel.html
+++ b/articles/going-green-vegan-vegetarian-travel.html
@@ -317,13 +317,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/going-green-vegan-vegetarian-travel/1080/400.webp
+                  https://picsum.photos/seed/going-green-vegan-vegetarian-7bf984/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/going-green-vegan-vegetarian-travel/1080/400.jpg
+                  https://picsum.photos/seed/going-green-vegan-vegetarian-7bf984/1080/400.jpg
                 "
               />
 
@@ -332,19 +332,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/going-green-vegan-vegetarian-travel/800/300.webp
+                  https://picsum.photos/seed/going-green-vegan-vegetarian-7bf984/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/going-green-vegan-vegetarian-travel/800/300.jpg
+                  https://picsum.photos/seed/going-green-vegan-vegetarian-7bf984/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/going-green-vegan-vegetarian-travel/400/200.jpg"
+                src="https://picsum.photos/seed/going-green-vegan-vegetarian-7bf984/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/hidden-gems-uncharted-travel-destinations.html
+++ b/articles/hidden-gems-uncharted-travel-destinations.html
@@ -293,27 +293,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/hidden-gems-uncharted-travel-destinations/1080/400.webp"
+              srcset="https://picsum.photos/seed/hidden-gems-uncharted-travel-3fda14/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/hidden-gems-uncharted-travel-destinations/1080/400.jpg"
+              srcset="https://picsum.photos/seed/hidden-gems-uncharted-travel-3fda14/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/hidden-gems-uncharted-travel-destinations/800/300.webp"
+              srcset="https://picsum.photos/seed/hidden-gems-uncharted-travel-3fda14/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/hidden-gems-uncharted-travel-destinations/800/300.jpg"
+              srcset="https://picsum.photos/seed/hidden-gems-uncharted-travel-3fda14/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/hidden-gems-uncharted-travel-destinations/400/200.jpg"
+              src="https://picsum.photos/seed/hidden-gems-uncharted-travel-3fda14/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/historic-railways-world-journey.html
+++ b/articles/historic-railways-world-journey.html
@@ -329,27 +329,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/historic-railways-world-journey/1080/400.webp"
+              srcset="https://picsum.photos/seed/historic-railways-world-journey-ea02b9/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/historic-railways-world-journey/1080/400.jpg"
+              srcset="https://picsum.photos/seed/historic-railways-world-journey-ea02b9/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/historic-railways-world-journey/800/300.webp"
+              srcset="https://picsum.photos/seed/historic-railways-world-journey-ea02b9/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/historic-railways-world-journey/800/300.jpg"
+              srcset="https://picsum.photos/seed/historic-railways-world-journey-ea02b9/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/historic-railways-world-journey/400/200.jpg"
+              src="https://picsum.photos/seed/historic-railways-world-journey-ea02b9/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/inspiring-travel-destinations-tips-2025-adventures.html
+++ b/articles/inspiring-travel-destinations-tips-2025-adventures.html
@@ -264,13 +264,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/inspiring-travel-destinations-tips-2025-adventures/1080/400.webp
+                  https://picsum.photos/seed/inspiring-travel-destinations-tips-1cf8d0/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/inspiring-travel-destinations-tips-2025-adventures/1080/400.jpg
+                  https://picsum.photos/seed/inspiring-travel-destinations-tips-1cf8d0/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -278,18 +278,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/inspiring-travel-destinations-tips-2025-adventures/800/300.webp
+                  https://picsum.photos/seed/inspiring-travel-destinations-tips-1cf8d0/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/inspiring-travel-destinations-tips-2025-adventures/800/300.jpg
+                  https://picsum.photos/seed/inspiring-travel-destinations-tips-1cf8d0/800/300.jpg
                 "
               />
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/inspiring-travel-destinations-tips-2025-adventures/400/200.jpg"
+                src="https://picsum.photos/seed/inspiring-travel-destinations-tips-1cf8d0/400/200.jpg"
                 alt="Scenic landscape inspiring safe 2025 travel adventures"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/navigating-complexities-of-travel-tips-tales-realities.html
+++ b/articles/navigating-complexities-of-travel-tips-tales-realities.html
@@ -265,13 +265,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-the-complexities-of-travel-tales-tips-realities/1080/400.webp
+                  https://picsum.photos/seed/navigating-the-complexities-of-4abcb9/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-the-complexities-of-travel-tales-tips-realities/1080/400.jpg
+                  https://picsum.photos/seed/navigating-the-complexities-of-4abcb9/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -279,18 +279,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-the-complexities-of-travel-tales-tips-realities/800/300.webp
+                  https://picsum.photos/seed/navigating-the-complexities-of-4abcb9/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-the-complexities-of-travel-tales-tips-realities/800/300.jpg
+                  https://picsum.photos/seed/navigating-the-complexities-of-4abcb9/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/navigating-the-complexities-of-travel-tales-tips-realities/480/240.jpg"
+                src="https://picsum.photos/seed/navigating-the-complexities-of-4abcb9/480/240.jpg"
                 alt="Traveler recalibrating plans with an offline map during a delay"
                 width="1080"
                 height="400"
@@ -465,13 +465,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-complexities-of-travel-tips-tales-realities/1080/400.webp
+                  https://picsum.photos/seed/navigating-complexities-of-travel-511ea0/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-complexities-of-travel-tips-tales-realities/1080/400.jpg
+                  https://picsum.photos/seed/navigating-complexities-of-travel-511ea0/1080/400.jpg
                 "
               />
 
@@ -480,19 +480,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-complexities-of-travel-tips-tales-realities/800/300.webp
+                  https://picsum.photos/seed/navigating-complexities-of-travel-511ea0/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-complexities-of-travel-tips-tales-realities/800/300.jpg
+                  https://picsum.photos/seed/navigating-complexities-of-travel-511ea0/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/navigating-complexities-of-travel-tips-tales-realities/400/200.jpg"
+                src="https://picsum.photos/seed/navigating-complexities-of-travel-511ea0/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html
+++ b/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html
@@ -267,13 +267,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-global-travel-unique-destinations-challenges-cultural-insights/1080/400.webp
+                  https://picsum.photos/seed/navigating-global-travel-unique-ffaff5/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-global-travel-unique-destinations-challenges-cultural-insights/1080/400.jpg
+                  https://picsum.photos/seed/navigating-global-travel-unique-ffaff5/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -281,18 +281,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-global-travel-unique-destinations-challenges-cultural-insights/800/300.webp
+                  https://picsum.photos/seed/navigating-global-travel-unique-ffaff5/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-global-travel-unique-destinations-challenges-cultural-insights/800/300.jpg
+                  https://picsum.photos/seed/navigating-global-travel-unique-ffaff5/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/navigating-global-travel-unique-destinations-challenges-cultural-insights/480/240.jpg"
+                src="https://picsum.photos/seed/navigating-global-travel-unique-ffaff5/480/240.jpg"
                 alt="Quiet rail stop in the hills with a small market street beyond"
                 width="1080"
                 height="400"
@@ -490,13 +490,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-global-travel-unique-destinations-challenges-cultural-insights/1080/400.webp
+                  https://picsum.photos/seed/navigating-global-travel-unique-ffaff5/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-global-travel-unique-destinations-challenges-cultural-insights/1080/400.jpg
+                  https://picsum.photos/seed/navigating-global-travel-unique-ffaff5/1080/400.jpg
                 "
               />
 
@@ -505,19 +505,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-global-travel-unique-destinations-challenges-cultural-insights/800/300.webp
+                  https://picsum.photos/seed/navigating-global-travel-unique-ffaff5/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-global-travel-unique-destinations-challenges-cultural-insights/800/300.jpg
+                  https://picsum.photos/seed/navigating-global-travel-unique-ffaff5/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/navigating-global-travel-unique-destinations-challenges-cultural-insights/400/200.jpg"
+                src="https://picsum.photos/seed/navigating-global-travel-unique-ffaff5/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html
+++ b/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html
@@ -404,27 +404,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/navigating-modern-travel-experiences-challenges-emerging-destinations/1080/400.webp"
+              srcset="https://picsum.photos/seed/navigating-modern-travel-experiences-c1f47f/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/navigating-modern-travel-experiences-challenges-emerging-destinations/1080/400.jpg"
+              srcset="https://picsum.photos/seed/navigating-modern-travel-experiences-c1f47f/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/navigating-modern-travel-experiences-challenges-emerging-destinations/800/300.webp"
+              srcset="https://picsum.photos/seed/navigating-modern-travel-experiences-c1f47f/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/navigating-modern-travel-experiences-challenges-emerging-destinations/800/300.jpg"
+              srcset="https://picsum.photos/seed/navigating-modern-travel-experiences-c1f47f/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/navigating-modern-travel-experiences-challenges-emerging-destinations/400/200.jpg"
+              src="https://picsum.photos/seed/navigating-modern-travel-experiences-c1f47f/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/navigating-modern-travel-insights-experiences-tips-2025.html
+++ b/articles/navigating-modern-travel-insights-experiences-tips-2025.html
@@ -359,27 +359,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/navigating-modern-travel-insights-experiences-tips-2025/1080/400.webp"
+              srcset="https://picsum.photos/seed/navigating-modern-travel-insights-5abad7/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/navigating-modern-travel-insights-experiences-tips-2025/1080/400.jpg"
+              srcset="https://picsum.photos/seed/navigating-modern-travel-insights-5abad7/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/navigating-modern-travel-insights-experiences-tips-2025/800/300.webp"
+              srcset="https://picsum.photos/seed/navigating-modern-travel-insights-5abad7/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/navigating-modern-travel-insights-experiences-tips-2025/800/300.jpg"
+              srcset="https://picsum.photos/seed/navigating-modern-travel-insights-5abad7/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/navigating-modern-travel-insights-experiences-tips-2025/400/200.jpg"
+              src="https://picsum.photos/seed/navigating-modern-travel-insights-5abad7/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html
+++ b/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html
@@ -270,13 +270,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-modern-travel-safety-culture-unique-destinations-2025/1080/400.webp
+                  https://picsum.photos/seed/navigating-modern-travel-safety-148f2f/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-modern-travel-safety-culture-unique-destinations-2025/1080/400.jpg
+                  https://picsum.photos/seed/navigating-modern-travel-safety-148f2f/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -284,18 +284,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-modern-travel-safety-culture-unique-destinations-2025/800/300.webp
+                  https://picsum.photos/seed/navigating-modern-travel-safety-148f2f/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-modern-travel-safety-culture-unique-destinations-2025/800/300.jpg
+                  https://picsum.photos/seed/navigating-modern-travel-safety-148f2f/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/navigating-modern-travel-safety-culture-unique-destinations-2025/480/240.jpg"
+                src="https://picsum.photos/seed/navigating-modern-travel-safety-148f2f/480/240.jpg"
                 alt="Traveler reviewing an offline itinerary and safety checklist at a station"
                 width="1080"
                 height="400"
@@ -485,13 +485,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-modern-travel-safety-culture-unique-destinations-2025/1080/400.webp
+                  https://picsum.photos/seed/navigating-modern-travel-safety-148f2f/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-modern-travel-safety-culture-unique-destinations-2025/1080/400.jpg
+                  https://picsum.photos/seed/navigating-modern-travel-safety-148f2f/1080/400.jpg
                 "
               />
 
@@ -500,19 +500,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-modern-travel-safety-culture-unique-destinations-2025/800/300.webp
+                  https://picsum.photos/seed/navigating-modern-travel-safety-148f2f/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-modern-travel-safety-culture-unique-destinations-2025/800/300.jpg
+                  https://picsum.photos/seed/navigating-modern-travel-safety-148f2f/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/navigating-modern-travel-safety-culture-unique-destinations-2025/400/200.jpg"
+                src="https://picsum.photos/seed/navigating-modern-travel-safety-148f2f/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/navigating-modern-travel-safety-tips-destinations-experiences.html
+++ b/articles/navigating-modern-travel-safety-tips-destinations-experiences.html
@@ -369,27 +369,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/navigating-modern-travel-safety-tips-destinations-experiences/1080/400.webp"
+              srcset="https://picsum.photos/seed/navigating-modern-travel-safety-d19c75/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/navigating-modern-travel-safety-tips-destinations-experiences/1080/400.jpg"
+              srcset="https://picsum.photos/seed/navigating-modern-travel-safety-d19c75/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/navigating-modern-travel-safety-tips-destinations-experiences/800/300.webp"
+              srcset="https://picsum.photos/seed/navigating-modern-travel-safety-d19c75/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/navigating-modern-travel-safety-tips-destinations-experiences/800/300.jpg"
+              srcset="https://picsum.photos/seed/navigating-modern-travel-safety-d19c75/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/navigating-modern-travel-safety-tips-destinations-experiences/400/200.jpg"
+              src="https://picsum.photos/seed/navigating-modern-travel-safety-d19c75/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/navigating-night-markets-food-lovers-guide.html
+++ b/articles/navigating-night-markets-food-lovers-guide.html
@@ -322,27 +322,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/navigating-night-markets-food-lovers-guide/1080/400.webp"
+              srcset="https://picsum.photos/seed/navigating-night-markets-food-fd201a/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/navigating-night-markets-food-lovers-guide/1080/400.jpg"
+              srcset="https://picsum.photos/seed/navigating-night-markets-food-fd201a/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/navigating-night-markets-food-lovers-guide/800/300.webp"
+              srcset="https://picsum.photos/seed/navigating-night-markets-food-fd201a/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/navigating-night-markets-food-lovers-guide/800/300.jpg"
+              srcset="https://picsum.photos/seed/navigating-night-markets-food-fd201a/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/navigating-night-markets-food-lovers-guide/400/200.jpg"
+              src="https://picsum.photos/seed/navigating-night-markets-food-fd201a/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/navigating-realities-wonders-modern-travel-2025.html
+++ b/articles/navigating-realities-wonders-modern-travel-2025.html
@@ -370,27 +370,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/navigating-realities-wonders-modern-travel-2025/1080/400.webp"
+              srcset="https://picsum.photos/seed/navigating-realities-wonders-modern-e9feb8/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/navigating-realities-wonders-modern-travel-2025/1080/400.jpg"
+              srcset="https://picsum.photos/seed/navigating-realities-wonders-modern-e9feb8/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/navigating-realities-wonders-modern-travel-2025/800/300.webp"
+              srcset="https://picsum.photos/seed/navigating-realities-wonders-modern-e9feb8/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/navigating-realities-wonders-modern-travel-2025/800/300.jpg"
+              srcset="https://picsum.photos/seed/navigating-realities-wonders-modern-e9feb8/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/navigating-realities-wonders-modern-travel-2025/400/200.jpg"
+              src="https://picsum.photos/seed/navigating-realities-wonders-modern-e9feb8/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/navigating-solo-journeys-travel-challenges-2025.html
+++ b/articles/navigating-solo-journeys-travel-challenges-2025.html
@@ -266,13 +266,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-solo-journeys-travel-challenges-2025/1080/400.webp
+                  https://picsum.photos/seed/navigating-solo-journeys-travel-aa27b3/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-solo-journeys-travel-challenges-2025/1080/400.jpg
+                  https://picsum.photos/seed/navigating-solo-journeys-travel-aa27b3/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -280,18 +280,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-solo-journeys-travel-challenges-2025/800/300.webp
+                  https://picsum.photos/seed/navigating-solo-journeys-travel-aa27b3/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-solo-journeys-travel-challenges-2025/800/300.jpg
+                  https://picsum.photos/seed/navigating-solo-journeys-travel-aa27b3/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/navigating-solo-journeys-travel-challenges-2025/480/240.jpg"
+                src="https://picsum.photos/seed/navigating-solo-journeys-travel-aa27b3/480/240.jpg"
                 alt="Solo traveler checking an offline route and safety notes on a station platform"
                 width="1080"
                 height="400"
@@ -485,13 +485,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-solo-journeys-travel-challenges-2025/1080/400.webp
+                  https://picsum.photos/seed/navigating-solo-journeys-travel-aa27b3/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-solo-journeys-travel-challenges-2025/1080/400.jpg
+                  https://picsum.photos/seed/navigating-solo-journeys-travel-aa27b3/1080/400.jpg
                 "
               />
 
@@ -500,19 +500,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-solo-journeys-travel-challenges-2025/800/300.webp
+                  https://picsum.photos/seed/navigating-solo-journeys-travel-aa27b3/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-solo-journeys-travel-challenges-2025/800/300.jpg
+                  https://picsum.photos/seed/navigating-solo-journeys-travel-aa27b3/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/navigating-solo-journeys-travel-challenges-2025/400/200.jpg"
+                src="https://picsum.photos/seed/navigating-solo-journeys-travel-aa27b3/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html
+++ b/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html
@@ -299,13 +299,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-emerging-travel-trends-unique-hobby-inspirations/1080/400.webp
+                  https://picsum.photos/seed/exploring-emerging-travel-trends-71dae6/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-emerging-travel-trends-unique-hobby-inspirations/1080/400.jpg
+                  https://picsum.photos/seed/exploring-emerging-travel-trends-71dae6/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -313,18 +313,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-emerging-travel-trends-unique-hobby-inspirations/800/300.webp
+                  https://picsum.photos/seed/exploring-emerging-travel-trends-71dae6/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/exploring-emerging-travel-trends-unique-hobby-inspirations/800/300.jpg
+                  https://picsum.photos/seed/exploring-emerging-travel-trends-71dae6/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/exploring-emerging-travel-trends-unique-hobby-inspirations/480/240.jpg"
+                src="https://picsum.photos/seed/exploring-emerging-travel-trends-71dae6/480/240.jpg"
                 alt="Traveler marking flexible plan options on an offline city map at a café table"
                 width="1080"
                 height="400"
@@ -460,13 +460,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-travel-experiences-tips-challenges-inspiring-journeys/1080/400.webp
+                  https://picsum.photos/seed/navigating-travel-experiences-tips-db38f9/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-travel-experiences-tips-challenges-inspiring-journeys/1080/400.jpg
+                  https://picsum.photos/seed/navigating-travel-experiences-tips-db38f9/1080/400.jpg
                 "
               />
 
@@ -475,19 +475,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-travel-experiences-tips-challenges-inspiring-journeys/800/300.webp
+                  https://picsum.photos/seed/navigating-travel-experiences-tips-db38f9/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/navigating-travel-experiences-tips-challenges-inspiring-journeys/800/300.jpg
+                  https://picsum.photos/seed/navigating-travel-experiences-tips-db38f9/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/navigating-travel-experiences-tips-challenges-inspiring-journeys/400/200.jpg"
+                src="https://picsum.photos/seed/navigating-travel-experiences-tips-db38f9/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/pedal-paradises-destinations-cycling-enthusiasts.html
+++ b/articles/pedal-paradises-destinations-cycling-enthusiasts.html
@@ -327,13 +327,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/pedal-paradises-destinations-cycling-enthusiasts/1080/400.webp
+                  https://picsum.photos/seed/pedal-paradises-destinations-cycling-603483/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/pedal-paradises-destinations-cycling-enthusiasts/1080/400.jpg
+                  https://picsum.photos/seed/pedal-paradises-destinations-cycling-603483/1080/400.jpg
                 "
               />
 
@@ -342,19 +342,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/pedal-paradises-destinations-cycling-enthusiasts/800/300.webp
+                  https://picsum.photos/seed/pedal-paradises-destinations-cycling-603483/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/pedal-paradises-destinations-cycling-enthusiasts/800/300.jpg
+                  https://picsum.photos/seed/pedal-paradises-destinations-cycling-603483/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/pedal-paradises-destinations-cycling-enthusiasts/400/200.jpg"
+                src="https://picsum.photos/seed/pedal-paradises-destinations-cycling-603483/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/river-cruises-europe.html
+++ b/articles/river-cruises-europe.html
@@ -314,13 +314,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/river-cruises-europe/1080/400.webp
+                  https://picsum.photos/seed/river-cruises-europe-7cf2a6/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/river-cruises-europe/1080/400.jpg
+                  https://picsum.photos/seed/river-cruises-europe-7cf2a6/1080/400.jpg
                 "
               />
 
@@ -329,19 +329,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/river-cruises-europe/800/300.webp
+                  https://picsum.photos/seed/river-cruises-europe-7cf2a6/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/river-cruises-europe/800/300.jpg
+                  https://picsum.photos/seed/river-cruises-europe-7cf2a6/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/river-cruises-europe/400/200.jpg"
+                src="https://picsum.photos/seed/river-cruises-europe-7cf2a6/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/roaming-roof-world-himalayas-guide.html
+++ b/articles/roaming-roof-world-himalayas-guide.html
@@ -329,13 +329,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/roaming-roof-world-himalayas-guide/1080/400.webp
+                  https://picsum.photos/seed/roaming-roof-world-himalayas-8e8d35/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/roaming-roof-world-himalayas-guide/1080/400.jpg
+                  https://picsum.photos/seed/roaming-roof-world-himalayas-8e8d35/1080/400.jpg
                 "
               />
 
@@ -344,19 +344,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/roaming-roof-world-himalayas-guide/800/300.webp
+                  https://picsum.photos/seed/roaming-roof-world-himalayas-8e8d35/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/roaming-roof-world-himalayas-guide/800/300.jpg
+                  https://picsum.photos/seed/roaming-roof-world-himalayas-8e8d35/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/roaming-roof-world-himalayas-guide/400/200.jpg"
+                src="https://picsum.photos/seed/roaming-roof-world-himalayas-8e8d35/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/sanctuaries-sky-worlds-picturesque-mountain-retreats.html
+++ b/articles/sanctuaries-sky-worlds-picturesque-mountain-retreats.html
@@ -313,13 +313,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/sanctuaries-sky-worlds-picturesque-mountain-retreats/1080/400.webp
+                  https://picsum.photos/seed/sanctuaries-sky-worlds-picturesque-ca45c5/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/sanctuaries-sky-worlds-picturesque-mountain-retreats/1080/400.jpg
+                  https://picsum.photos/seed/sanctuaries-sky-worlds-picturesque-ca45c5/1080/400.jpg
                 "
               />
 
@@ -328,19 +328,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/sanctuaries-sky-worlds-picturesque-mountain-retreats/800/300.webp
+                  https://picsum.photos/seed/sanctuaries-sky-worlds-picturesque-ca45c5/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/sanctuaries-sky-worlds-picturesque-mountain-retreats/800/300.jpg
+                  https://picsum.photos/seed/sanctuaries-sky-worlds-picturesque-ca45c5/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/sanctuaries-sky-worlds-picturesque-mountain-retreats/400/200.jpg"
+                src="https://picsum.photos/seed/sanctuaries-sky-worlds-picturesque-ca45c5/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/solo-travel-guide-southeast-asia-safety.html
+++ b/articles/solo-travel-guide-southeast-asia-safety.html
@@ -322,27 +322,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/solo-travel-guide-southeast-asia-safety/1080/400.webp"
+              srcset="https://picsum.photos/seed/solo-travel-guide-southeast-273432/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/solo-travel-guide-southeast-asia-safety/1080/400.jpg"
+              srcset="https://picsum.photos/seed/solo-travel-guide-southeast-273432/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/solo-travel-guide-southeast-asia-safety/800/300.webp"
+              srcset="https://picsum.photos/seed/solo-travel-guide-southeast-273432/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/solo-travel-guide-southeast-asia-safety/800/300.jpg"
+              srcset="https://picsum.photos/seed/solo-travel-guide-southeast-273432/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/solo-travel-guide-southeast-asia-safety/400/200.jpg"
+              src="https://picsum.photos/seed/solo-travel-guide-southeast-273432/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/solo-travel-safety-guide.html
+++ b/articles/solo-travel-safety-guide.html
@@ -315,27 +315,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/solo-travel-safety-guide/1080/400.webp"
+              srcset="https://picsum.photos/seed/solo-travel-safety-guide-25ae46/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/solo-travel-safety-guide/1080/400.jpg"
+              srcset="https://picsum.photos/seed/solo-travel-safety-guide-25ae46/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/solo-travel-safety-guide/800/300.webp"
+              srcset="https://picsum.photos/seed/solo-travel-safety-guide-25ae46/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/solo-travel-safety-guide/800/300.jpg"
+              srcset="https://picsum.photos/seed/solo-travel-safety-guide-25ae46/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/solo-travel-safety-guide/400/200.jpg"
+              src="https://picsum.photos/seed/solo-travel-safety-guide-25ae46/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/sustainable-food-explorations.html
+++ b/articles/sustainable-food-explorations.html
@@ -333,27 +333,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/sustainable-food-explorations/1080/400.webp"
+              srcset="https://picsum.photos/seed/sustainable-food-explorations-cc8393/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/sustainable-food-explorations/1080/400.jpg"
+              srcset="https://picsum.photos/seed/sustainable-food-explorations-cc8393/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/sustainable-food-explorations/800/300.webp"
+              srcset="https://picsum.photos/seed/sustainable-food-explorations-cc8393/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/sustainable-food-explorations/800/300.jpg"
+              srcset="https://picsum.photos/seed/sustainable-food-explorations-cc8393/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/sustainable-food-explorations/400/200.jpg"
+              src="https://picsum.photos/seed/sustainable-food-explorations-cc8393/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/timeless-timelines-history-iconic-landmarks.html
+++ b/articles/timeless-timelines-history-iconic-landmarks.html
@@ -316,27 +316,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/timeless-timelines-history-iconic-landmarks/1080/400.webp"
+              srcset="https://picsum.photos/seed/timeless-timelines-history-iconic-b37366/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/timeless-timelines-history-iconic-landmarks/1080/400.jpg"
+              srcset="https://picsum.photos/seed/timeless-timelines-history-iconic-b37366/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/timeless-timelines-history-iconic-landmarks/800/300.webp"
+              srcset="https://picsum.photos/seed/timeless-timelines-history-iconic-b37366/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/timeless-timelines-history-iconic-landmarks/800/300.jpg"
+              srcset="https://picsum.photos/seed/timeless-timelines-history-iconic-b37366/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/timeless-timelines-history-iconic-landmarks/400/200.jpg"
+              src="https://picsum.photos/seed/timeless-timelines-history-iconic-b37366/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/top-10-hidden-gems-europe.html
+++ b/articles/top-10-hidden-gems-europe.html
@@ -314,27 +314,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/top-10-hidden-gems-europe/1080/400.webp"
+              srcset="https://picsum.photos/seed/top-10-hidden-gems-775978/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/top-10-hidden-gems-europe/1080/400.jpg"
+              srcset="https://picsum.photos/seed/top-10-hidden-gems-775978/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/top-10-hidden-gems-europe/800/300.webp"
+              srcset="https://picsum.photos/seed/top-10-hidden-gems-775978/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/top-10-hidden-gems-europe/800/300.jpg"
+              srcset="https://picsum.photos/seed/top-10-hidden-gems-775978/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/top-10-hidden-gems-europe/400/200.jpg"
+              src="https://picsum.photos/seed/top-10-hidden-gems-775978/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/top-surfing-destinations-world.html
+++ b/articles/top-surfing-destinations-world.html
@@ -335,27 +335,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/top-surfing-destinations-world/1080/400.webp"
+              srcset="https://picsum.photos/seed/top-surfing-destinations-world-455224/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/top-surfing-destinations-world/1080/400.jpg"
+              srcset="https://picsum.photos/seed/top-surfing-destinations-world-455224/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/top-surfing-destinations-world/800/300.webp"
+              srcset="https://picsum.photos/seed/top-surfing-destinations-world-455224/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/top-surfing-destinations-world/800/300.jpg"
+              srcset="https://picsum.photos/seed/top-surfing-destinations-world-455224/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/top-surfing-destinations-world/400/200.jpg"
+              src="https://picsum.photos/seed/top-surfing-destinations-world-455224/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/touring-tropics-comprehensive-guide.html
+++ b/articles/touring-tropics-comprehensive-guide.html
@@ -305,27 +305,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/touring-tropics-comprehensive-guide/1080/400.webp"
+              srcset="https://picsum.photos/seed/touring-tropics-comprehensive-guide-d4f03b/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/touring-tropics-comprehensive-guide/1080/400.jpg"
+              srcset="https://picsum.photos/seed/touring-tropics-comprehensive-guide-d4f03b/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/touring-tropics-comprehensive-guide/800/300.webp"
+              srcset="https://picsum.photos/seed/touring-tropics-comprehensive-guide-d4f03b/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/touring-tropics-comprehensive-guide/800/300.jpg"
+              srcset="https://picsum.photos/seed/touring-tropics-comprehensive-guide-d4f03b/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/touring-tropics-comprehensive-guide/400/200.jpg"
+              src="https://picsum.photos/seed/touring-tropics-comprehensive-guide-d4f03b/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/transcontinental-trails-world.html
+++ b/articles/transcontinental-trails-world.html
@@ -338,13 +338,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/transcontinental-trails-world/1080/400.webp
+                  https://picsum.photos/seed/transcontinental-trails-world-3243f8/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/transcontinental-trails-world/1080/400.jpg
+                  https://picsum.photos/seed/transcontinental-trails-world-3243f8/1080/400.jpg
                 "
               />
 
@@ -353,19 +353,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/transcontinental-trails-world/800/300.webp
+                  https://picsum.photos/seed/transcontinental-trails-world-3243f8/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/transcontinental-trails-world/800/300.jpg
+                  https://picsum.photos/seed/transcontinental-trails-world-3243f8/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/transcontinental-trails-world/400/200.jpg"
+                src="https://picsum.photos/seed/transcontinental-trails-world-3243f8/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/travel-budget-tips.html
+++ b/articles/travel-budget-tips.html
@@ -315,13 +315,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/travel-budget-tips/1080/400.webp
+                  https://picsum.photos/seed/travel-budget-tips-d54dac/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/travel-budget-tips/1080/400.jpg
+                  https://picsum.photos/seed/travel-budget-tips-d54dac/1080/400.jpg
                 "
               />
 
@@ -330,19 +330,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/travel-budget-tips/800/300.webp
+                  https://picsum.photos/seed/travel-budget-tips-d54dac/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/travel-budget-tips/800/300.jpg
+                  https://picsum.photos/seed/travel-budget-tips-d54dac/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/travel-budget-tips/400/200.jpg"
+                src="https://picsum.photos/seed/travel-budget-tips-d54dac/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html
+++ b/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html
@@ -275,13 +275,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/mastering-travel-flexibility-tips-inspiring-stories-adventurous-journeys/1080/400.webp
+                  https://picsum.photos/seed/mastering-travel-flexibility-tips-a01159/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/mastering-travel-flexibility-tips-inspiring-stories-adventurous-journeys/1080/400.jpg
+                  https://picsum.photos/seed/mastering-travel-flexibility-tips-a01159/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -289,18 +289,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/mastering-travel-flexibility-tips-inspiring-stories-adventurous-journeys/800/300.webp
+                  https://picsum.photos/seed/mastering-travel-flexibility-tips-a01159/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/mastering-travel-flexibility-tips-inspiring-stories-adventurous-journeys/800/300.jpg
+                  https://picsum.photos/seed/mastering-travel-flexibility-tips-a01159/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/mastering-travel-flexibility-tips-inspiring-stories-adventurous-journeys/480/240.jpg"
+                src="https://picsum.photos/seed/mastering-travel-flexibility-tips-a01159/480/240.jpg"
                 alt="Traveler updating a flexible day plan with an offline city map near a market"
                 width="1080"
                 height="400"
@@ -482,13 +482,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/travel-flexibility-tips-inspiring-adventurous-journeys/1080/400.webp
+                  https://picsum.photos/seed/travel-flexibility-tips-inspiring-1e4818/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/travel-flexibility-tips-inspiring-adventurous-journeys/1080/400.jpg
+                  https://picsum.photos/seed/travel-flexibility-tips-inspiring-1e4818/1080/400.jpg
                 "
               />
 
@@ -497,19 +497,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/travel-flexibility-tips-inspiring-adventurous-journeys/800/300.webp
+                  https://picsum.photos/seed/travel-flexibility-tips-inspiring-1e4818/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/travel-flexibility-tips-inspiring-adventurous-journeys/800/300.jpg
+                  https://picsum.photos/seed/travel-flexibility-tips-inspiring-1e4818/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/travel-flexibility-tips-inspiring-adventurous-journeys/400/200.jpg"
+                src="https://picsum.photos/seed/travel-flexibility-tips-inspiring-1e4818/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/travel-hacks-tips-save-money-time.html
+++ b/articles/travel-hacks-tips-save-money-time.html
@@ -310,27 +310,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/travel-hacks-tips-save-money-time/1080/400.webp"
+              srcset="https://picsum.photos/seed/travel-hacks-tips-save-691fa9/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/travel-hacks-tips-save-money-time/1080/400.jpg"
+              srcset="https://picsum.photos/seed/travel-hacks-tips-save-691fa9/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/travel-hacks-tips-save-money-time/800/300.webp"
+              srcset="https://picsum.photos/seed/travel-hacks-tips-save-691fa9/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/travel-hacks-tips-save-money-time/800/300.jpg"
+              srcset="https://picsum.photos/seed/travel-hacks-tips-save-691fa9/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/travel-hacks-tips-save-money-time/400/200.jpg"
+              src="https://picsum.photos/seed/travel-hacks-tips-save-691fa9/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/traveling-silk-road.html
+++ b/articles/traveling-silk-road.html
@@ -318,13 +318,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-silk-road/1080/400.webp
+                  https://picsum.photos/seed/traveling-silk-road-5f54c3/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-silk-road/1080/400.jpg
+                  https://picsum.photos/seed/traveling-silk-road-5f54c3/1080/400.jpg
                 "
               />
 
@@ -333,19 +333,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-silk-road/800/300.webp
+                  https://picsum.photos/seed/traveling-silk-road-5f54c3/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-silk-road/800/300.jpg
+                  https://picsum.photos/seed/traveling-silk-road-5f54c3/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/traveling-silk-road/400/200.jpg"
+                src="https://picsum.photos/seed/traveling-silk-road-5f54c3/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/traveling-through-taste-culinary-journey.html
+++ b/articles/traveling-through-taste-culinary-journey.html
@@ -320,13 +320,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-through-taste-culinary-journey/1080/400.webp
+                  https://picsum.photos/seed/traveling-through-taste-culinary-7fcb81/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-through-taste-culinary-journey/1080/400.jpg
+                  https://picsum.photos/seed/traveling-through-taste-culinary-7fcb81/1080/400.jpg
                 "
               />
 
@@ -335,19 +335,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-through-taste-culinary-journey/800/300.webp
+                  https://picsum.photos/seed/traveling-through-taste-culinary-7fcb81/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-through-taste-culinary-journey/800/300.jpg
+                  https://picsum.photos/seed/traveling-through-taste-culinary-7fcb81/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/traveling-through-taste-culinary-journey/400/200.jpg"
+                src="https://picsum.photos/seed/traveling-through-taste-culinary-7fcb81/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/traveling-through-time-oldest-cities.html
+++ b/articles/traveling-through-time-oldest-cities.html
@@ -331,13 +331,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-through-time-oldest-cities/1080/400.webp
+                  https://picsum.photos/seed/traveling-through-time-oldest-ab05fe/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-through-time-oldest-cities/1080/400.jpg
+                  https://picsum.photos/seed/traveling-through-time-oldest-ab05fe/1080/400.jpg
                 "
               />
 
@@ -346,19 +346,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-through-time-oldest-cities/800/300.webp
+                  https://picsum.photos/seed/traveling-through-time-oldest-ab05fe/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-through-time-oldest-cities/800/300.jpg
+                  https://picsum.photos/seed/traveling-through-time-oldest-ab05fe/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/traveling-through-time-oldest-cities/400/200.jpg"
+                src="https://picsum.photos/seed/traveling-through-time-oldest-ab05fe/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/traveling-twist-unique-festivals-globe.html
+++ b/articles/traveling-twist-unique-festivals-globe.html
@@ -294,27 +294,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/traveling-twist-unique-festivals-globe/1080/400.webp"
+              srcset="https://picsum.photos/seed/traveling-twist-unique-festivals-d37398/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/traveling-twist-unique-festivals-globe/1080/400.jpg"
+              srcset="https://picsum.photos/seed/traveling-twist-unique-festivals-d37398/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/traveling-twist-unique-festivals-globe/800/300.webp"
+              srcset="https://picsum.photos/seed/traveling-twist-unique-festivals-d37398/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/traveling-twist-unique-festivals-globe/800/300.jpg"
+              srcset="https://picsum.photos/seed/traveling-twist-unique-festivals-d37398/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/traveling-twist-unique-festivals-globe/400/200.jpg"
+              src="https://picsum.photos/seed/traveling-twist-unique-festivals-d37398/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/traveling-without-trace.html
+++ b/articles/traveling-without-trace.html
@@ -328,13 +328,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-without-trace/1080/400.webp
+                  https://picsum.photos/seed/traveling-without-trace-4336ba/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-without-trace/1080/400.jpg
+                  https://picsum.photos/seed/traveling-without-trace-4336ba/1080/400.jpg
                 "
               />
 
@@ -343,19 +343,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-without-trace/800/300.webp
+                  https://picsum.photos/seed/traveling-without-trace-4336ba/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/traveling-without-trace/800/300.jpg
+                  https://picsum.photos/seed/traveling-without-trace-4336ba/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/traveling-without-trace/400/200.jpg"
+                src="https://picsum.photos/seed/traveling-without-trace-4336ba/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/ultimate-family-solo-travel-planning-tips-2025.html
+++ b/articles/ultimate-family-solo-travel-planning-tips-2025.html
@@ -269,13 +269,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-family-and-solo-travel-planning-tips-and-destinations-2025/1080/400.webp
+                  https://picsum.photos/seed/ultimate-family-and-solo-5ba1b8/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-family-and-solo-travel-planning-tips-and-destinations-2025/1080/400.jpg
+                  https://picsum.photos/seed/ultimate-family-and-solo-5ba1b8/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -283,18 +283,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-family-and-solo-travel-planning-tips-and-destinations-2025/800/300.webp
+                  https://picsum.photos/seed/ultimate-family-and-solo-5ba1b8/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-family-and-solo-travel-planning-tips-and-destinations-2025/800/300.jpg
+                  https://picsum.photos/seed/ultimate-family-and-solo-5ba1b8/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/ultimate-family-and-solo-travel-planning-tips-and-destinations-2025/480/240.jpg"
+                src="https://picsum.photos/seed/ultimate-family-and-solo-5ba1b8/480/240.jpg"
                 alt="Family walking through a park near a transit stop with picnic gear"
                 width="1080"
                 height="400"
@@ -477,13 +477,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-family-solo-travel-planning-tips-2025/1080/400.webp
+                  https://picsum.photos/seed/ultimate-family-solo-travel-0024f0/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-family-solo-travel-planning-tips-2025/1080/400.jpg
+                  https://picsum.photos/seed/ultimate-family-solo-travel-0024f0/1080/400.jpg
                 "
               />
 
@@ -492,19 +492,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-family-solo-travel-planning-tips-2025/800/300.webp
+                  https://picsum.photos/seed/ultimate-family-solo-travel-0024f0/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-family-solo-travel-planning-tips-2025/800/300.jpg
+                  https://picsum.photos/seed/ultimate-family-solo-travel-0024f0/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/ultimate-family-solo-travel-planning-tips-2025/400/200.jpg"
+                src="https://picsum.photos/seed/ultimate-family-solo-travel-0024f0/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html
+++ b/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html
@@ -267,13 +267,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-travel-guide-tips-destinations-insider-experiences-2025/1080/400.webp
+                  https://picsum.photos/seed/ultimate-travel-guide-tips-902a62/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-travel-guide-tips-destinations-insider-experiences-2025/1080/400.jpg
+                  https://picsum.photos/seed/ultimate-travel-guide-tips-902a62/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -281,18 +281,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-travel-guide-tips-destinations-insider-experiences-2025/800/300.webp
+                  https://picsum.photos/seed/ultimate-travel-guide-tips-902a62/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-travel-guide-tips-destinations-insider-experiences-2025/800/300.jpg
+                  https://picsum.photos/seed/ultimate-travel-guide-tips-902a62/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/ultimate-travel-guide-tips-destinations-insider-experiences-2025/480/240.jpg"
+                src="https://picsum.photos/seed/ultimate-travel-guide-tips-902a62/480/240.jpg"
                 alt="Traveler checking an offline route at a station platform"
                 width="1080"
                 height="400"
@@ -476,13 +476,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-travel-guide-tips-destinations-insider-experiences-2025/1080/400.webp
+                  https://picsum.photos/seed/ultimate-travel-guide-tips-902a62/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-travel-guide-tips-destinations-insider-experiences-2025/1080/400.jpg
+                  https://picsum.photos/seed/ultimate-travel-guide-tips-902a62/1080/400.jpg
                 "
               />
 
@@ -491,19 +491,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-travel-guide-tips-destinations-insider-experiences-2025/800/300.webp
+                  https://picsum.photos/seed/ultimate-travel-guide-tips-902a62/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/ultimate-travel-guide-tips-destinations-insider-experiences-2025/800/300.jpg
+                  https://picsum.photos/seed/ultimate-travel-guide-tips-902a62/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/ultimate-travel-guide-tips-destinations-insider-experiences-2025/400/200.jpg"
+                src="https://picsum.photos/seed/ultimate-travel-guide-tips-902a62/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/unexpected-journeys-realities-modern-travel-experiences.html
+++ b/articles/unexpected-journeys-realities-modern-travel-experiences.html
@@ -271,13 +271,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unexpected-journeys-modern-travel-experiences/1080/400.webp
+                  https://picsum.photos/seed/unexpected-journeys-modern-travel-640f5c/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unexpected-journeys-modern-travel-experiences/1080/400.jpg
+                  https://picsum.photos/seed/unexpected-journeys-modern-travel-640f5c/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -285,18 +285,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unexpected-journeys-modern-travel-experiences/800/300.webp
+                  https://picsum.photos/seed/unexpected-journeys-modern-travel-640f5c/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unexpected-journeys-modern-travel-experiences/800/300.jpg
+                  https://picsum.photos/seed/unexpected-journeys-modern-travel-640f5c/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/unexpected-journeys-modern-travel-experiences/480/240.jpg"
+                src="https://picsum.photos/seed/unexpected-journeys-modern-travel-640f5c/480/240.jpg"
                 alt="Traveler reviewing a boarding pass and offline map near an airport information desk"
                 width="1080"
                 height="400"
@@ -465,13 +465,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unexpected-journeys-realities-modern-travel-experiences/1080/400.webp
+                  https://picsum.photos/seed/unexpected-journeys-realities-modern-b3e4e1/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unexpected-journeys-realities-modern-travel-experiences/1080/400.jpg
+                  https://picsum.photos/seed/unexpected-journeys-realities-modern-b3e4e1/1080/400.jpg
                 "
               />
 
@@ -480,19 +480,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unexpected-journeys-realities-modern-travel-experiences/800/300.webp
+                  https://picsum.photos/seed/unexpected-journeys-realities-modern-b3e4e1/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unexpected-journeys-realities-modern-travel-experiences/800/300.jpg
+                  https://picsum.photos/seed/unexpected-journeys-realities-modern-b3e4e1/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/unexpected-journeys-realities-modern-travel-experiences/400/200.jpg"
+                src="https://picsum.photos/seed/unexpected-journeys-realities-modern-b3e4e1/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html
+++ b/articles/unforgettable-travel-adventures-exploring-unique-destinations-safely.html
@@ -263,13 +263,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-unique-destinations-safely/1080/400.webp
+                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-99e935/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-unique-destinations-safely/1080/400.jpg
+                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-99e935/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -277,18 +277,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-unique-destinations-safely/800/300.webp
+                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-99e935/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-unique-destinations-safely/800/300.jpg
+                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-99e935/800/300.jpg
                 "
               />
               <!-- Mobile fallback -->
               <img
-                src="https://picsum.photos/seed/unforgettable-travel-adventures-exploring-unique-destinations-safely/400/200.jpg"
+                src="https://picsum.photos/seed/unforgettable-travel-adventures-exploring-99e935/400/200.jpg"
                 alt="Traveler checking an offline itinerary on a phone beside a station timetable"
                 width="1080"
                 height="400"
@@ -500,13 +500,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-unique-destinations-safely/1080/400.webp
+                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-99e935/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-unique-destinations-safely/1080/400.jpg
+                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-99e935/1080/400.jpg
                 "
               />
 
@@ -515,19 +515,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-unique-destinations-safely/800/300.webp
+                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-99e935/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-unique-destinations-safely/800/300.jpg
+                  https://picsum.photos/seed/unforgettable-travel-adventures-exploring-99e935/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/unforgettable-travel-adventures-exploring-unique-destinations-safely/400/200.jpg"
+                src="https://picsum.photos/seed/unforgettable-travel-adventures-exploring-99e935/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/unforgettable-travel-adventures-inspiring-journeys-world.html
+++ b/articles/unforgettable-travel-adventures-inspiring-journeys-world.html
@@ -340,13 +340,13 @@
               type="image/webp"
               media="(min-width:76rem)"
               srcset="
-                https://picsum.photos/seed/unforgettable-travel-adventures-inspiring-journeys-world/1080/400.webp
+                https://picsum.photos/seed/unforgettable-travel-adventures-inspiring-d446b0/1080/400.webp
               "
             />
             <source
               media="(min-width:76rem)"
               srcset="
-                https://picsum.photos/seed/unforgettable-travel-adventures-inspiring-journeys-world/1080/400.jpg
+                https://picsum.photos/seed/unforgettable-travel-adventures-inspiring-d446b0/1080/400.jpg
               "
             />
 
@@ -355,19 +355,19 @@
               type="image/webp"
               media="(min-width:38rem)"
               srcset="
-                https://picsum.photos/seed/unforgettable-travel-adventures-inspiring-journeys-world/800/300.webp
+                https://picsum.photos/seed/unforgettable-travel-adventures-inspiring-d446b0/800/300.webp
               "
             />
             <source
               media="(min-width:38rem)"
               srcset="
-                https://picsum.photos/seed/unforgettable-travel-adventures-inspiring-journeys-world/800/300.jpg
+                https://picsum.photos/seed/unforgettable-travel-adventures-inspiring-d446b0/800/300.jpg
               "
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/unforgettable-travel-adventures-inspiring-journeys-world/400/200.jpg"
+              src="https://picsum.photos/seed/unforgettable-travel-adventures-inspiring-d446b0/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/unforgettable-travel-experiences-top-destinations-2025.html
+++ b/articles/unforgettable-travel-experiences-top-destinations-2025.html
@@ -372,27 +372,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/unforgettable-travel-experiences-top-destinations-2025/1080/400.webp"
+              srcset="https://picsum.photos/seed/unforgettable-travel-experiences-top-a9e01f/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/unforgettable-travel-experiences-top-destinations-2025/1080/400.jpg"
+              srcset="https://picsum.photos/seed/unforgettable-travel-experiences-top-a9e01f/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/unforgettable-travel-experiences-top-destinations-2025/800/300.webp"
+              srcset="https://picsum.photos/seed/unforgettable-travel-experiences-top-a9e01f/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/unforgettable-travel-experiences-top-destinations-2025/800/300.jpg"
+              srcset="https://picsum.photos/seed/unforgettable-travel-experiences-top-a9e01f/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/unforgettable-travel-experiences-top-destinations-2025/400/200.jpg"
+              src="https://picsum.photos/seed/unforgettable-travel-experiences-top-a9e01f/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/unforgettable-travel-journeys-unique-destinations-experiences.html
+++ b/articles/unforgettable-travel-journeys-unique-destinations-experiences.html
@@ -287,13 +287,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-journeys-exploring-unique-destinations-and-experiences/1080/400.webp
+                  https://picsum.photos/seed/unforgettable-travel-journeys-exploring-6a2d8b/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-journeys-exploring-unique-destinations-and-experiences/1080/400.jpg
+                  https://picsum.photos/seed/unforgettable-travel-journeys-exploring-6a2d8b/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -301,18 +301,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-journeys-exploring-unique-destinations-and-experiences/800/300.webp
+                  https://picsum.photos/seed/unforgettable-travel-journeys-exploring-6a2d8b/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-journeys-exploring-unique-destinations-and-experiences/800/300.jpg
+                  https://picsum.photos/seed/unforgettable-travel-journeys-exploring-6a2d8b/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/unforgettable-travel-journeys-exploring-unique-destinations-and-experiences/480/240.jpg"
+                src="https://picsum.photos/seed/unforgettable-travel-journeys-exploring-6a2d8b/480/240.jpg"
                 alt="Quiet neighborhood street with local cafés and small workshops in the early morning light"
                 width="1080"
                 height="400"
@@ -443,13 +443,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-journeys-unique-destinations-experiences/1080/400.webp
+                  https://picsum.photos/seed/unforgettable-travel-journeys-unique-4da1ea/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-journeys-unique-destinations-experiences/1080/400.jpg
+                  https://picsum.photos/seed/unforgettable-travel-journeys-unique-4da1ea/1080/400.jpg
                 "
               />
 
@@ -458,19 +458,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-journeys-unique-destinations-experiences/800/300.webp
+                  https://picsum.photos/seed/unforgettable-travel-journeys-unique-4da1ea/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-journeys-unique-destinations-experiences/800/300.jpg
+                  https://picsum.photos/seed/unforgettable-travel-journeys-unique-4da1ea/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/unforgettable-travel-journeys-unique-destinations-experiences/400/200.jpg"
+                src="https://picsum.photos/seed/unforgettable-travel-journeys-unique-4da1ea/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html
+++ b/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html
@@ -265,13 +265,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-stories-and-expert-tips-2025-adventures/1080/400.webp
+                  https://picsum.photos/seed/unforgettable-travel-stories-and-bafe1a/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-stories-and-expert-tips-2025-adventures/1080/400.jpg
+                  https://picsum.photos/seed/unforgettable-travel-stories-and-bafe1a/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -279,18 +279,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-stories-and-expert-tips-2025-adventures/800/300.webp
+                  https://picsum.photos/seed/unforgettable-travel-stories-and-bafe1a/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-stories-and-expert-tips-2025-adventures/800/300.jpg
+                  https://picsum.photos/seed/unforgettable-travel-stories-and-bafe1a/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/unforgettable-travel-stories-and-expert-tips-2025-adventures/480/240.jpg"
+                src="https://picsum.photos/seed/unforgettable-travel-stories-and-bafe1a/480/240.jpg"
                 alt="Traveler watching early morning mist drift over a mountain ridge"
                 width="1080"
                 height="400"
@@ -455,13 +455,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-stories-expert-tips-2025-adventures/1080/400.webp
+                  https://picsum.photos/seed/unforgettable-travel-stories-expert-707904/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-stories-expert-tips-2025-adventures/1080/400.jpg
+                  https://picsum.photos/seed/unforgettable-travel-stories-expert-707904/1080/400.jpg
                 "
               />
 
@@ -470,19 +470,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-stories-expert-tips-2025-adventures/800/300.webp
+                  https://picsum.photos/seed/unforgettable-travel-stories-expert-707904/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unforgettable-travel-stories-expert-tips-2025-adventures/800/300.jpg
+                  https://picsum.photos/seed/unforgettable-travel-stories-expert-707904/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/unforgettable-travel-stories-expert-tips-2025-adventures/400/200.jpg"
+                src="https://picsum.photos/seed/unforgettable-travel-stories-expert-707904/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/unplanned-journeys-travel-realities-insights.html
+++ b/articles/unplanned-journeys-travel-realities-insights.html
@@ -269,13 +269,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unplanned-journeys-travel-realities-insights-savvy-adventurers/1080/400.webp
+                  https://picsum.photos/seed/unplanned-journeys-travel-realities-512c20/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unplanned-journeys-travel-realities-insights-savvy-adventurers/1080/400.jpg
+                  https://picsum.photos/seed/unplanned-journeys-travel-realities-512c20/1080/400.jpg
                 "
               />
               <!-- Tablet -->
@@ -283,18 +283,18 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unplanned-journeys-travel-realities-insights-savvy-adventurers/800/300.webp
+                  https://picsum.photos/seed/unplanned-journeys-travel-realities-512c20/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unplanned-journeys-travel-realities-insights-savvy-adventurers/800/300.jpg
+                  https://picsum.photos/seed/unplanned-journeys-travel-realities-512c20/800/300.jpg
                 "
               />
               <!-- Mobile -->
               <img
-                src="https://picsum.photos/seed/unplanned-journeys-travel-realities-insights-savvy-adventurers/480/240.jpg"
+                src="https://picsum.photos/seed/unplanned-journeys-travel-realities-512c20/480/240.jpg"
                 alt="Traveler adjusting plans with an offline map near a lively neighborhood market"
                 width="1080"
                 height="400"
@@ -465,13 +465,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unplanned-journeys-travel-realities-insights/1080/400.webp
+                  https://picsum.photos/seed/unplanned-journeys-travel-realities-9a19f8/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unplanned-journeys-travel-realities-insights/1080/400.jpg
+                  https://picsum.photos/seed/unplanned-journeys-travel-realities-9a19f8/1080/400.jpg
                 "
               />
 
@@ -480,19 +480,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unplanned-journeys-travel-realities-insights/800/300.webp
+                  https://picsum.photos/seed/unplanned-journeys-travel-realities-9a19f8/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unplanned-journeys-travel-realities-insights/800/300.jpg
+                  https://picsum.photos/seed/unplanned-journeys-travel-realities-9a19f8/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/unplanned-journeys-travel-realities-insights/400/200.jpg"
+                src="https://picsum.photos/seed/unplanned-journeys-travel-realities-9a19f8/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/unplugged-adventures-travel-without-technology.html
+++ b/articles/unplugged-adventures-travel-without-technology.html
@@ -304,27 +304,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/unplugged-adventures-travel-without-technology/1080/400.webp"
+              srcset="https://picsum.photos/seed/unplugged-adventures-travel-without-69aba7/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/unplugged-adventures-travel-without-technology/1080/400.jpg"
+              srcset="https://picsum.photos/seed/unplugged-adventures-travel-without-69aba7/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/unplugged-adventures-travel-without-technology/800/300.webp"
+              srcset="https://picsum.photos/seed/unplugged-adventures-travel-without-69aba7/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/unplugged-adventures-travel-without-technology/800/300.jpg"
+              srcset="https://picsum.photos/seed/unplugged-adventures-travel-without-69aba7/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/unplugged-adventures-travel-without-technology/400/200.jpg"
+              src="https://picsum.photos/seed/unplugged-adventures-travel-without-69aba7/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/unveiling-magic-polar-expeditions.html
+++ b/articles/unveiling-magic-polar-expeditions.html
@@ -319,13 +319,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unveiling-magic-polar-expeditions/1080/400.webp
+                  https://picsum.photos/seed/unveiling-magic-polar-expeditions-3730b8/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/unveiling-magic-polar-expeditions/1080/400.jpg
+                  https://picsum.photos/seed/unveiling-magic-polar-expeditions-3730b8/1080/400.jpg
                 "
               />
 
@@ -334,19 +334,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unveiling-magic-polar-expeditions/800/300.webp
+                  https://picsum.photos/seed/unveiling-magic-polar-expeditions-3730b8/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/unveiling-magic-polar-expeditions/800/300.jpg
+                  https://picsum.photos/seed/unveiling-magic-polar-expeditions-3730b8/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/unveiling-magic-polar-expeditions/400/200.jpg"
+                src="https://picsum.photos/seed/unveiling-magic-polar-expeditions-3730b8/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/visit-earth-extremities.html
+++ b/articles/visit-earth-extremities.html
@@ -318,27 +318,27 @@
             <source
               type="image/webp"
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/visit-earth-extremities/1080/400.webp"
+              srcset="https://picsum.photos/seed/visit-earth-extremities-ff2b6c/1080/400.webp"
             />
             <source
               media="(min-width:76rem)"
-              srcset="https://picsum.photos/seed/visit-earth-extremities/1080/400.jpg"
+              srcset="https://picsum.photos/seed/visit-earth-extremities-ff2b6c/1080/400.jpg"
             />
 
             <!-- Tablet -->
             <source
               type="image/webp"
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/visit-earth-extremities/800/300.webp"
+              srcset="https://picsum.photos/seed/visit-earth-extremities-ff2b6c/800/300.webp"
             />
             <source
               media="(min-width:38rem)"
-              srcset="https://picsum.photos/seed/visit-earth-extremities/800/300.jpg"
+              srcset="https://picsum.photos/seed/visit-earth-extremities-ff2b6c/800/300.jpg"
             />
 
             <!-- Mobile Fallback -->
             <img
-              src="https://picsum.photos/seed/visit-earth-extremities/400/200.jpg"
+              src="https://picsum.photos/seed/visit-earth-extremities-ff2b6c/400/200.jpg"
               alt="Random placeholder photo"
               title="Photo via https://picsum.photos"
               width="1080"

--- a/articles/voluntourism-impactful-travel.html
+++ b/articles/voluntourism-impactful-travel.html
@@ -316,13 +316,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/voluntourism-impactful-travel/1080/400.webp
+                  https://picsum.photos/seed/voluntourism-impactful-travel-d9deeb/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/voluntourism-impactful-travel/1080/400.jpg
+                  https://picsum.photos/seed/voluntourism-impactful-travel-d9deeb/1080/400.jpg
                 "
               />
 
@@ -331,19 +331,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/voluntourism-impactful-travel/800/300.webp
+                  https://picsum.photos/seed/voluntourism-impactful-travel-d9deeb/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/voluntourism-impactful-travel/800/300.jpg
+                  https://picsum.photos/seed/voluntourism-impactful-travel-d9deeb/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/voluntourism-impactful-travel/400/200.jpg"
+                src="https://picsum.photos/seed/voluntourism-impactful-travel-d9deeb/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/articles/voyage-through-vineyards-global-wine-regions.html
+++ b/articles/voyage-through-vineyards-global-wine-regions.html
@@ -330,13 +330,13 @@
                 type="image/webp"
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/voyage-through-vineyards-global-wine-regions/1080/400.webp
+                  https://picsum.photos/seed/voyage-through-vineyards-global-0ae6f6/1080/400.webp
                 "
               />
               <source
                 media="(min-width:76rem)"
                 srcset="
-                  https://picsum.photos/seed/voyage-through-vineyards-global-wine-regions/1080/400.jpg
+                  https://picsum.photos/seed/voyage-through-vineyards-global-0ae6f6/1080/400.jpg
                 "
               />
 
@@ -345,19 +345,19 @@
                 type="image/webp"
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/voyage-through-vineyards-global-wine-regions/800/300.webp
+                  https://picsum.photos/seed/voyage-through-vineyards-global-0ae6f6/800/300.webp
                 "
               />
               <source
                 media="(min-width:38rem)"
                 srcset="
-                  https://picsum.photos/seed/voyage-through-vineyards-global-wine-regions/800/300.jpg
+                  https://picsum.photos/seed/voyage-through-vineyards-global-0ae6f6/800/300.jpg
                 "
               />
 
               <!-- Mobile Fallback -->
               <img
-                src="https://picsum.photos/seed/voyage-through-vineyards-global-wine-regions/400/200.jpg"
+                src="https://picsum.photos/seed/voyage-through-vineyards-global-0ae6f6/400/200.jpg"
                 alt="Random placeholder photo"
                 title="Photo via https://picsum.photos"
                 width="1080"

--- a/latest-articles.html
+++ b/latest-articles.html
@@ -65,42 +65,6 @@
       <h1>Latest Articles</h1>
       <section id="results">
     <div class="card">
-      <a aria-label="aerial photography of body of water during daytime" href="/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html">
-        <picture>
-          <img src="https://images.unsplash.com/photo-1520285774798-2f1616131a68?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxsdXh1cnklMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnMlMjAyMDI1fGVufDB8MHx8fDE3NTE4ODI0NDN8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1520285774798-2f1616131a68?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxsdXh1cnklMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnMlMjAyMDI1fGVufDB8MHx8fDE3NTE4ODI0NDN8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
-                https://images.unsplash.com/photo-1520285774798-2f1616131a68?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxsdXh1cnklMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnMlMjAyMDI1fGVufDB8MHx8fDE3NTE4ODI0NDN8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="aerial photography of body of water during daytime" loading="lazy" decoding="async" width="1300" height="500" />
-        </picture>
-      </a>
-
-      <h3><a href="/articles/ultimate-travel-guide-tips-destinations-insider-experiences-2025.html">Ultimate Travel Guide: Tips, Destinations, and Insider Experiences for 2025</a></h3>
-
-      <div id="published">
-        Published:
-        <em><time itemprop="datePublished" datetime="2025-07-07">
-            July 7, 2025</time></em>
-      </div>
-
-      <p>Get ready to unlock the secrets of unforgettable adventures with our Ultimate Travel Guide for 2025, packed with tips, top destinations, and insider experiences. From expert advice to exciting places, let’s dive into essential travel tips that will elevate your next journey.</p>
-    </div>
-    <div class="card">
-      <a aria-label="black and gray camera on open map" href="/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html">
-        <picture>
-          <img src="https://images.unsplash.com/photo-1503220954697-e02095e8e0d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUzNjE3MzIxfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1503220954697-e02095e8e0d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUzNjE3MzIxfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
-                https://images.unsplash.com/photo-1503220954697-e02095e8e0d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUzNjE3MzIxfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="black and gray camera on open map" loading="lazy" decoding="async" width="1300" height="500" />
-        </picture>
-      </a>
-
-      <h3><a href="/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html">Mastering Travel Flexibility: Tips and Inspiring Stories for Adventurous Journeys</a></h3>
-
-      <div id="published">
-        Published:
-        <em><time itemprop="datePublished" datetime="2025-07-27">
-            July 27, 2025</time></em>
-      </div>
-
-      <p>Mastering travel flexibility unlocks thrilling adventures and opens the door to unforgettable experiences. Let’s dive into embracing unpredictability and start with how flexibility fuels adventurous journeys.</p>
-    </div>
-    <div class="card">
       <a aria-label="people standing on brown sand under blue sky during daytime" href="/articles/unforgettable-travel-stories-expert-tips-2025-adventures.html">
         <picture>
           <img src="https://images.unsplash.com/photo-1608984075444-0e67cd80f696?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwdHJhdmVsJTIwbGFuZHNjYXBlc3xlbnwwfDB8fHwxNzUxODM5MjUyfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1608984075444-0e67cd80f696?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwdHJhdmVsJTIwbGFuZHNjYXBlc3xlbnwwfDB8fHwxNzUxODM5MjUyfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
@@ -117,60 +81,6 @@
       </div>
 
       <p>Unforgettable travel stories ignite the passion for exploring new horizons, offering inspiration for your 2025 adventures. Dive into remarkable experiences and expert tips that set the stage for safe, culturally rich journeys ahead.</p>
-    </div>
-    <div class="card">
-      <a aria-label="a group of people walking down a hallway" href="/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html">
-        <picture>
-          <img src="https://images.unsplash.com/photo-1647161407063-d49d91a5e6b8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHklMjBjdWx0dXJhbCUyMGRpdmVyc2l0eSUyMHVuaXF1ZSUyMGRlc3RpbmF0aW9ucyUyMDIwMjV8ZW58MHwwfHx8MTc1MTk2ODg1OXww&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1647161407063-d49d91a5e6b8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHklMjBjdWx0dXJhbCUyMGRpdmVyc2l0eSUyMHVuaXF1ZSUyMGRlc3RpbmF0aW9ucyUyMDIwMjV8ZW58MHwwfHx8MTc1MTk2ODg1OXww&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
-                https://images.unsplash.com/photo-1647161407063-d49d91a5e6b8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHklMjBjdWx0dXJhbCUyMGRpdmVyc2l0eSUyMHVuaXF1ZSUyMGRlc3RpbmF0aW9ucyUyMDIwMjV8ZW58MHwwfHx8MTc1MTk2ODg1OXww&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="a group of people walking down a hallway" loading="lazy" decoding="async" width="1300" height="500" />
-        </picture>
-      </a>
-
-      <h3><a href="/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html">Navigating Modern Travel: Safety, Culture, and Unique Destinations in 2025</a></h3>
-
-      <div id="published">
-        Published:
-        <em><time itemprop="datePublished" datetime="2025-07-08">
-            July 8, 2025</time></em>
-      </div>
-
-      <p>Modern travel in 2025 presents new challenges and exciting opportunities that require careful planning. From ensuring safety to embracing cultural immersion, this guide begins with essential travel safety tips for a secure journey.</p>
-    </div>
-    <div class="card">
-      <a aria-label="a traffic light on a pole with a sky background" href="/articles/navigating-modern-travel-safety-tips-destinations-experiences.html">
-        <picture>
-          <img src="https://images.unsplash.com/photo-1718242869012-34c2587f50aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHl8ZW58MHwwfHx8MTc1MjA3OTU0Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1718242869012-34c2587f50aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHl8ZW58MHwwfHx8MTc1MjA3OTU0Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
-                https://images.unsplash.com/photo-1718242869012-34c2587f50aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHl8ZW58MHwwfHx8MTc1MjA3OTU0Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="a traffic light on a pole with a sky background" loading="lazy" decoding="async" width="1300" height="500" />
-        </picture>
-      </a>
-
-      <h3><a href="/articles/navigating-modern-travel-safety-tips-destinations-experiences.html">Navigating Modern Travel: Safety Tips, Destinations, and Experiences</a></h3>
-
-      <div id="published">
-        Published:
-        <em><time itemprop="datePublished" datetime="2025-07-09">
-            July 9, 2025</time></em>
-      </div>
-
-      <p>Navigating modern travel requires a balance of excitement and caution as new challenges and opportunities arise. This guide will equip you with essential safety tips and practical advice to handle disruptions, empowering you to explore top destinations with confidence.</p>
-    </div>
-    <div class="card">
-      <a aria-label="man wearing white shirt overlooking on white clouds" href="/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html">
-        <picture>
-          <img src="https://images.unsplash.com/photo-1612257998531-70e0d0a15f6d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTUyNjI0OTJ8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1612257998531-70e0d0a15f6d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTUyNjI0OTJ8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
-                https://images.unsplash.com/photo-1612257998531-70e0d0a15f6d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTUyNjI0OTJ8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="man wearing white shirt overlooking on white clouds" loading="lazy" decoding="async" width="1300" height="500" />
-        </picture>
-      </a>
-
-      <h3><a href="/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html">Navigating Modern Travel: Experiences, Challenges, and Emerging Destinations</a></h3>
-
-      <div id="published">
-        Published:
-        <em><time itemprop="datePublished" datetime="2025-08-15">
-            August 15, 2025</time></em>
-      </div>
-
-      <p>Navigating the world of modern travel introduces a mix of exciting experiences and unexpected challenges. This article begins by exploring key travel experiences in 2025 that set the stage for contemporary journeys.</p>
     </div>
     <div class="card">
       <a aria-label="the word travel spelled with scrabbles on a wooden table" href="/articles/discover-transformative-travel-stories-trending-destinations.html">
@@ -191,6 +101,24 @@
       <p>Transformative travel stories reveal how exploring new destinations can spark personal growth and unforgettable adventures. Let’s dive into how embracing these experiences can change your perspective and explore the top trending travel destinations for 2025.</p>
     </div>
     <div class="card">
+      <a aria-label="black and gray camera on open map" href="/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html">
+        <picture>
+          <img src="https://images.unsplash.com/photo-1503220954697-e02095e8e0d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUzNjE3MzIxfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1503220954697-e02095e8e0d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUzNjE3MzIxfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1503220954697-e02095e8e0d5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBwbGFubmluZ3xlbnwwfDB8fHwxNzUzNjE3MzIxfDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="black and gray camera on open map" loading="lazy" decoding="async" width="1300" height="500" />
+        </picture>
+      </a>
+
+      <h3><a href="/articles/travel-flexibility-tips-inspiring-adventurous-journeys.html">Mastering Travel Flexibility: Tips and Inspiring Stories for Adventurous Journeys</a></h3>
+
+      <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="2025-07-27">
+            July 27, 2025</time></em>
+      </div>
+
+      <p>Mastering travel flexibility unlocks thrilling adventures and opens the door to unforgettable experiences. Let’s dive into embracing unpredictability and start with how flexibility fuels adventurous journeys.</p>
+    </div>
+    <div class="card">
       <a aria-label="people gathering near the hut lot during daytime" href="/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html">
         <picture>
           <img src="https://images.unsplash.com/photo-1560643248-d9c6124b2a44?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3aW5kaW5nJTIwbW91bnRhaW4lMjByb2FkcyUyMHJlbW90ZSUyMHZpbGxhZ2UlMjBjdWx0dXJhbCUyMGZlc3RpdmFsfGVufDB8MHx8fDE3NTMxOTAwNzR8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1560643248-d9c6124b2a44?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3aW5kaW5nJTIwbW91bnRhaW4lMjByb2FkcyUyMHJlbW90ZSUyMHZpbGxhZ2UlMjBjdWx0dXJhbCUyMGZlc3RpdmFsfGVufDB8MHx8fDE3NTMxOTAwNzR8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
@@ -207,6 +135,96 @@
       </div>
 
       <p>Global travel invites explorers to venture beyond typical tourist spots, uncovering unique destinations rich in culture and challenge. This journey begins by exploring off-the-beaten-path locations that reveal authentic experiences and set the stage for meaningful adventures.</p>
+    </div>
+    <div class="card">
+      <a aria-label="man wearing white shirt overlooking on white clouds" href="/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html">
+        <picture>
+          <img src="https://images.unsplash.com/photo-1612257998531-70e0d0a15f6d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTUyNjI0OTJ8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1612257998531-70e0d0a15f6d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTUyNjI0OTJ8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1612257998531-70e0d0a15f6d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBhZHZlbnR1cmVzfGVufDB8MHx8fDE3NTUyNjI0OTJ8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="man wearing white shirt overlooking on white clouds" loading="lazy" decoding="async" width="1300" height="500" />
+        </picture>
+      </a>
+
+      <h3><a href="/articles/navigating-modern-travel-experiences-challenges-emerging-destinations.html">Navigating Modern Travel: Experiences, Challenges, and Emerging Destinations</a></h3>
+
+      <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="2025-08-15">
+            August 15, 2025</time></em>
+      </div>
+
+      <p>Navigating the world of modern travel introduces a mix of exciting experiences and unexpected challenges. This article begins by exploring key travel experiences in 2025 that set the stage for contemporary journeys.</p>
+    </div>
+    <div class="card">
+      <a aria-label="green trees near body of water during daytime" href="/articles/unforgettable-travel-journeys-unique-destinations-experiences.html">
+        <picture>
+          <img src="https://images.unsplash.com/photo-1609464528647-bd84b5b6b461?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxleG90aWMlMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnN8ZW58MHwwfHx8MTc1NTI0NDcyMnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1609464528647-bd84b5b6b461?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxleG90aWMlMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnN8ZW58MHwwfHx8MTc1NTI0NDcyMnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1609464528647-bd84b5b6b461?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxleG90aWMlMjB0cmF2ZWwlMjBkZXN0aW5hdGlvbnN8ZW58MHwwfHx8MTc1NTI0NDcyMnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="green trees near body of water during daytime" loading="lazy" decoding="async" width="1300" height="500" />
+        </picture>
+      </a>
+
+      <h3><a href="/articles/unforgettable-travel-journeys-unique-destinations-experiences.html">Unforgettable Travel Journeys: Exploring Unique Destinations and Experiences</a></h3>
+
+      <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="2025-08-15">
+            August 15, 2025</time></em>
+      </div>
+
+      <p>Embark on unforgettable travel journeys that lead you to unique destinations and extraordinary experiences around the globe. From discovering hidden gems to planning your 2025 adventures, this guide begins with uncovering travel experiences that truly stand out.</p>
+    </div>
+    <div class="card">
+      <a aria-label="a traffic light on a pole with a sky background" href="/articles/navigating-modern-travel-safety-tips-destinations-experiences.html">
+        <picture>
+          <img src="https://images.unsplash.com/photo-1718242869012-34c2587f50aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHl8ZW58MHwwfHx8MTc1MjA3OTU0Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1718242869012-34c2587f50aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHl8ZW58MHwwfHx8MTc1MjA3OTU0Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1718242869012-34c2587f50aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHl8ZW58MHwwfHx8MTc1MjA3OTU0Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="a traffic light on a pole with a sky background" loading="lazy" decoding="async" width="1300" height="500" />
+        </picture>
+      </a>
+
+      <h3><a href="/articles/navigating-modern-travel-safety-tips-destinations-experiences.html">Navigating Modern Travel: Safety Tips, Destinations, and Experiences</a></h3>
+
+      <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="2025-07-09">
+            July 9, 2025</time></em>
+      </div>
+
+      <p>Navigating modern travel requires a balance of excitement and caution as new challenges and opportunities arise. This guide will equip you with essential safety tips and practical advice to handle disruptions, empowering you to explore top destinations with confidence.</p>
+    </div>
+    <div class="card">
+      <a aria-label="a group of people walking down a hallway" href="/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html">
+        <picture>
+          <img src="https://images.unsplash.com/photo-1647161407063-d49d91a5e6b8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHklMjBjdWx0dXJhbCUyMGRpdmVyc2l0eSUyMHVuaXF1ZSUyMGRlc3RpbmF0aW9ucyUyMDIwMjV8ZW58MHwwfHx8MTc1MTk2ODg1OXww&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1647161407063-d49d91a5e6b8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHklMjBjdWx0dXJhbCUyMGRpdmVyc2l0eSUyMHVuaXF1ZSUyMGRlc3RpbmF0aW9ucyUyMDIwMjV8ZW58MHwwfHx8MTc1MTk2ODg1OXww&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1647161407063-d49d91a5e6b8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxtb2Rlcm4lMjB0cmF2ZWwlMjBzYWZldHklMjBjdWx0dXJhbCUyMGRpdmVyc2l0eSUyMHVuaXF1ZSUyMGRlc3RpbmF0aW9ucyUyMDIwMjV8ZW58MHwwfHx8MTc1MTk2ODg1OXww&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="a group of people walking down a hallway" loading="lazy" decoding="async" width="1300" height="500" />
+        </picture>
+      </a>
+
+      <h3><a href="/articles/navigating-modern-travel-safety-culture-unique-destinations-2025.html">Navigating Modern Travel: Safety, Culture, and Unique Destinations in 2025</a></h3>
+
+      <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="2025-07-08">
+            July 8, 2025</time></em>
+      </div>
+
+      <p>Modern travel in 2025 presents new challenges and exciting opportunities that require careful planning. From ensuring safety to embracing cultural immersion, this guide begins with essential travel safety tips for a secure journey.</p>
+    </div>
+    <div class="card">
+      <a aria-label="a mountain range with trees in the foreground and a cloudy sky in the background" href="/articles/unforgettable-travel-adventures-inspiring-journeys-world.html">
+        <picture>
+          <img src="https://images.unsplash.com/photo-1634864221446-d7f305974814?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwbW91bnRhaW4lMjBsYW5kc2NhcGVzfGVufDB8MHx8fDE3NTM2MTc4Nzh8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1634864221446-d7f305974814?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwbW91bnRhaW4lMjBsYW5kc2NhcGVzfGVufDB8MHx8fDE3NTM2MTc4Nzh8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1634864221446-d7f305974814?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwbW91bnRhaW4lMjBsYW5kc2NhcGVzfGVufDB8MHx8fDE3NTM2MTc4Nzh8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="a mountain range with trees in the foreground and a cloudy sky in the background" loading="lazy" decoding="async" width="1300" height="500" />
+        </picture>
+      </a>
+
+      <h3><a href="/articles/unforgettable-travel-adventures-inspiring-journeys-world.html">Unforgettable Travel Adventures and Inspiring Journeys Around the World</a></h3>
+
+      <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="2025-07-27">
+            July 27, 2025</time></em>
+      </div>
+
+      <p>Embark on a journey to explore unforgettable travel adventures and inspiring stories from around the world that ignite your wanderlust. From top destinations to empowering solo trips, this guide opens the door to experiences that will transform how you travel.</p>
     </div>
       </section>
     </main>

--- a/most-read-articles.html
+++ b/most-read-articles.html
@@ -65,112 +65,149 @@
       <h1>Most Read Articles</h1>
       <section id="results">
     <div class="card">
-      <a aria-label="adult gray elephant stands near gray bush" href="/articles/best-safari-destinations.html">
+      <a aria-label="a car driving down a dirt road in the mountains" href="/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html">
         <picture>
-          <img src="https://images.unsplash.com/photo-1517003142208-feb84c80413e?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxzYWZhcmklMjB3aWxkbGlmZSUyMGFkdmVudHVyZSUyMGFuaW1hbHMlMjBuYXR1cmUlMjBsYW5kc2NhcGV8ZW58MHx8fHwxNzQ1NDQzMDk3fDA&ixlib=rb-4.0.3&q=80&w=1300&h=500" srcset="https://images.unsplash.com/photo-1517003142208-feb84c80413e?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxzYWZhcmklMjB3aWxkbGlmZSUyMGFkdmVudHVyZSUyMGFuaW1hbHMlMjBuYXR1cmUlMjBsYW5kc2NhcGV8ZW58MHx8fHwxNzQ1NDQzMDk3fDA&ixlib=rb-4.0.3&q=80&w=1300&h=500&dpr=2 2x,
-                https://images.unsplash.com/photo-1517003142208-feb84c80413e?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxzYWZhcmklMjB3aWxkbGlmZSUyMGFkdmVudHVyZSUyMGFuaW1hbHMlMjBuYXR1cmUlMjBsYW5kc2NhcGV8ZW58MHx8fHwxNzQ1NDQzMDk3fDA&ixlib=rb-4.0.3&q=80&w=1300&h=500 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="adult gray elephant stands near gray bush" loading="lazy" decoding="async" width="1300" height="500" />
+          <img src="https://images.unsplash.com/photo-1643889037313-7bda0ccc3d69?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3YW5kZXJsdXN0JTIwcm9hZCUyMHRyaXAlMjBzY2VuaWMlMjBsYW5kc2NhcGVzJTIwY3VsdHVyYWwlMjBpbW1lcnNpb258ZW58MHwwfHx8MTc1MTEwNTA3N3ww&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1643889037313-7bda0ccc3d69?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3YW5kZXJsdXN0JTIwcm9hZCUyMHRyaXAlMjBzY2VuaWMlMjBsYW5kc2NhcGVzJTIwY3VsdHVyYWwlMjBpbW1lcnNpb258ZW58MHwwfHx8MTc1MTEwNTA3N3ww&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1643889037313-7bda0ccc3d69?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3YW5kZXJsdXN0JTIwcm9hZCUyMHRyaXAlMjBzY2VuaWMlMjBsYW5kc2NhcGVzJTIwY3VsdHVyYWwlMjBpbW1lcnNpb258ZW58MHwwfHx8MTc1MTEwNTA3N3ww&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="a car driving down a dirt road in the mountains" loading="lazy" decoding="async" width="1300" height="500" />
         </picture>
       </a>
 
-      <h3><a href="/articles/best-safari-destinations.html">Experiencing Wildlife: Best Safari Destinations Around the Globe</a></h3>
+      <h3><a href="/articles/navigating-travel-experiences-tips-challenges-inspiring-journeys.html">Navigating Travel Experiences: Tips, Challenges, and Inspiring Journeys</a></h3>
 
       <div id="published">
         Published:
-        <em><time itemprop="datePublished" datetime="2025-02-16">
-            February 16, 2025</time></em>
+        <em><time itemprop="datePublished" datetime="2025-06-28">
+            June 28, 2025</time></em>
       </div>
 
-      <p>Embarking on a safari is one of the most exhilarating ways to connect with nature and witness incredible wildlife in their natural habitats. Whether you're seeking the grandeur of African plains, lush rainforests, or Arctic tundras, the world's best safari destinations offer unforgettable experiences for nature lovers and adventure seekers alike. Let’s explore these extraordinary wilderness areas around the globe.</p>
+      <p>Travel opens doors to diverse cultures and unforgettable experiences, but it also presents unique challenges along the way. This article delves into essential travel tips that ensure smoother journeys and prepares you to overcome common obstacles with confidence.</p>
     </div>
     <div class="card">
-      <a aria-label="Pesto pasta with sliced tomatoes served on white ceramic plate" href="/articles/traveling-through-taste-culinary-journey.html">
+      <a aria-label="a mountain range with trees in the foreground and a cloudy sky in the background" href="/articles/unforgettable-travel-adventures-inspiring-journeys-world.html">
         <picture>
-          <img src="https://images.unsplash.com/photo-1473093295043-cdd812d0e601?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxpbnRlcm5hdGlvbmFsJTIwY3Vpc2luZSUyQyUyMGZvb2QlMjBtYXJrZXRzJTJDJTIwc3RyZWV0JTIwZm9vZCUyQyUyMGdsb2JhbCUyMGRpc2hlcyUyQyUyMGN1bHR1cmFsJTIwZm9vZHxlbnwwfHx8fDE3NDUzNjAzMjJ8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500" srcset="https://images.unsplash.com/photo-1473093295043-cdd812d0e601?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxpbnRlcm5hdGlvbmFsJTIwY3Vpc2luZSUyQyUyMGZvb2QlMjBtYXJrZXRzJTJDJTIwc3RyZWV0JTIwZm9vZCUyQyUyMGdsb2JhbCUyMGRpc2hlcyUyQyUyMGN1bHR1cmFsJTIwZm9vZHxlbnwwfHx8fDE3NDUzNjAzMjJ8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500&dpr=2 2x,
-                https://images.unsplash.com/photo-1473093295043-cdd812d0e601?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxpbnRlcm5hdGlvbmFsJTIwY3Vpc2luZSUyQyUyMGZvb2QlMjBtYXJrZXRzJTJDJTIwc3RyZWV0JTIwZm9vZCUyQyUyMGdsb2JhbCUyMGRpc2hlcyUyQyUyMGN1bHR1cmFsJTIwZm9vZHxlbnwwfHx8fDE3NDUzNjAzMjJ8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="Pesto pasta with sliced tomatoes served on white ceramic plate" loading="lazy" decoding="async" width="1300" height="500" />
+          <img src="https://images.unsplash.com/photo-1634864221446-d7f305974814?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwbW91bnRhaW4lMjBsYW5kc2NhcGVzfGVufDB8MHx8fDE3NTM2MTc4Nzh8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1634864221446-d7f305974814?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwbW91bnRhaW4lMjBsYW5kc2NhcGVzfGVufDB8MHx8fDE3NTM2MTc4Nzh8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1634864221446-d7f305974814?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlcGljJTIwbW91bnRhaW4lMjBsYW5kc2NhcGVzfGVufDB8MHx8fDE3NTM2MTc4Nzh8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="a mountain range with trees in the foreground and a cloudy sky in the background" loading="lazy" decoding="async" width="1300" height="500" />
         </picture>
       </a>
 
-      <h3><a href="/articles/traveling-through-taste-culinary-journey.html">Traveling Through Taste: A Culinary Journey Around the Globe</a></h3>
+      <h3><a href="/articles/unforgettable-travel-adventures-inspiring-journeys-world.html">Unforgettable Travel Adventures and Inspiring Journeys Around the World</a></h3>
 
       <div id="published">
         Published:
-        <em><time itemprop="datePublished" datetime="2024-12-05">
-            December 5, 2024</time></em>
+        <em><time itemprop="datePublished" datetime="2025-07-27">
+            July 27, 2025</time></em>
       </div>
 
-      <p>Imagine savoring the vibrant flavors of a Thai street market, indulging in hearty Italian pasta, or tasting spicy Mexican tacos—all without leaving your home. This culinary journey explores the rich tapestry of global cuisine, uncovering the stories, traditions, and unique ingredients that make each region’s food special. Prepare your senses for an unforgettable taste adventure worldwide.</p>
+      <p>Embark on a journey to explore unforgettable travel adventures and inspiring stories from around the world that ignite your wanderlust. From top destinations to empowering solo trips, this guide opens the door to experiences that will transform how you travel.</p>
     </div>
     <div class="card">
-      <a aria-label="person holding blue and brown map" href="/articles/digital-nomad-life-world.html">
+      <a aria-label="A chandelier hangs under a majestic domed ceiling." href="/articles/navigating-complexities-of-travel-tips-tales-realities.html">
         <picture>
-          <img src="https://images.unsplash.com/photo-1504598318550-17eba1008a68?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxkaWdpdGFsJTIwbm9tYWQlMkMlMjByZW1vdGUlMjB3b3JrJTJDJTIwdHJhdmVsJTJDJTIwd29ybGQlMjBleHBsb3JhdGlvbiUyQyUyMGxhcHRvcCUyMG91dGRvb3JzfGVufDB8fHx8MTc0NTQ0MzAwNHww&ixlib=rb-4.0.3&q=80&w=1300&h=500" srcset="https://images.unsplash.com/photo-1504598318550-17eba1008a68?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxkaWdpdGFsJTIwbm9tYWQlMkMlMjByZW1vdGUlMjB3b3JrJTJDJTIwdHJhdmVsJTJDJTIwd29ybGQlMjBleHBsb3JhdGlvbiUyQyUyMGxhcHRvcCUyMG91dGRvb3JzfGVufDB8fHx8MTc0NTQ0MzAwNHww&ixlib=rb-4.0.3&q=80&w=1300&h=500&dpr=2 2x,
-                https://images.unsplash.com/photo-1504598318550-17eba1008a68?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxkaWdpdGFsJTIwbm9tYWQlMkMlMjByZW1vdGUlMjB3b3JrJTJDJTIwdHJhdmVsJTJDJTIwd29ybGQlMjBleHBsb3JhdGlvbiUyQyUyMGxhcHRvcCUyMG91dGRvb3JzfGVufDB8fHx8MTc0NTQ0MzAwNHww&ixlib=rb-4.0.3&q=80&w=1300&h=500 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="person holding blue and brown map" loading="lazy" decoding="async" width="1300" height="500" />
+          <img src="https://images.unsplash.com/photo-1743795522843-38d3f294db1a?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBzdG9yeXRlbGxpbmd8ZW58MHwwfHx8MTc1MDgwMjQ1OXww&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1743795522843-38d3f294db1a?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBzdG9yeXRlbGxpbmd8ZW58MHwwfHx8MTc1MDgwMjQ1OXww&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1743795522843-38d3f294db1a?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxhZHZlbnR1cmUlMjB0cmF2ZWwlMjBzdG9yeXRlbGxpbmd8ZW58MHwwfHx8MTc1MDgwMjQ1OXww&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="A chandelier hangs under a majestic domed ceiling." loading="lazy" decoding="async" width="1300" height="500" />
         </picture>
       </a>
 
-      <h3><a href="/articles/digital-nomad-life-world.html">Digital Nomad Life: Exploring the World while Working Remotely</a></h3>
+      <h3><a href="/articles/navigating-complexities-of-travel-tips-tales-realities.html">Navigating the Complexities of Travel: Tales, Tips, and
+      Realities</a></h3>
 
       <div id="published">
         Published:
-        <em><time itemprop="datePublished" datetime="2025-02-03">
-            February 3, 2025</time></em>
+        <em><time itemprop="datePublished" datetime="2025-06-24">
+            June 24, 2025</time></em>
       </div>
 
-      <p>The digital nomad lifestyle offers a unique blend of work and travel, granting freedom to explore new places while maintaining a remote career. This guide uncovers the essentials, inspiring you to embrace mobility, adapt to diverse environments, and turn the dream of working from beautiful locations into reality. Whether a beginner or seasoned traveler, learn how to balance productivity with adventure.</p>
+      <p>Travel offers a spectrum of experiences, from inspiring personal adventures to unpredictable challenges. This article shares insights into real travel stories, safety essentials, and smart strategies to help you navigate your journeys with confidence.</p>
     </div>
     <div class="card">
-      <a aria-label="A view of a valley with mountains in the background" href="/articles/roaming-roof-world-himalayas-guide.html">
+      <a aria-label="grayscale photo of low angle view of building" href="/articles/timeless-timelines-history-iconic-landmarks.html">
         <picture>
-          <img src="https://images.unsplash.com/photo-1736914329552-a8e43dcee31f?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxIaW1hbGF5YXMlMjBtb3VudGFpbnMlMjB0cmVra2luZyUyMGFkdmVudHVyZSUyMHBlYWtzJTIwdmlsbGFnZXxlbnwwfHx8fDE3NDU0NDIzNTB8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500" srcset="https://images.unsplash.com/photo-1736914329552-a8e43dcee31f?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxIaW1hbGF5YXMlMjBtb3VudGFpbnMlMjB0cmVra2luZyUyMGFkdmVudHVyZSUyMHBlYWtzJTIwdmlsbGFnZXxlbnwwfHx8fDE3NDU0NDIzNTB8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500&dpr=2 2x,
-                https://images.unsplash.com/photo-1736914329552-a8e43dcee31f?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxIaW1hbGF5YXMlMjBtb3VudGFpbnMlMjB0cmVra2luZyUyMGFkdmVudHVyZSUyMHBlYWtzJTIwdmlsbGFnZXxlbnwwfHx8fDE3NDU0NDIzNTB8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="A view of a valley with mountains in the background" loading="lazy" decoding="async" width="1300" height="500" />
+          <img src="https://images.unsplash.com/photo-1527576539890-dfa815648363?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxoaXN0b3JpYyUyMGxhbmRtYXJrcyUyQyUyMGFyY2hpdGVjdHVyZSUyQyUyMGFuY2llbnQlMjBydWlucyUyQyUyMGNpdHlzY2FwZXMlMkMlMjBjdWx0dXJhbCUyMGhlcml0YWdlfGVufDB8fHx8MTc0NTQ0MjMyNnww&ixlib=rb-4.0.3&q=80&w=1300&h=500" srcset="https://images.unsplash.com/photo-1527576539890-dfa815648363?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxoaXN0b3JpYyUyMGxhbmRtYXJrcyUyQyUyMGFyY2hpdGVjdHVyZSUyQyUyMGFuY2llbnQlMjBydWlucyUyQyUyMGNpdHlzY2FwZXMlMkMlMjBjdWx0dXJhbCUyMGhlcml0YWdlfGVufDB8fHx8MTc0NTQ0MjMyNnww&ixlib=rb-4.0.3&q=80&w=1300&h=500&dpr=2 2x,
+                https://images.unsplash.com/photo-1527576539890-dfa815648363?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxoaXN0b3JpYyUyMGxhbmRtYXJrcyUyQyUyMGFyY2hpdGVjdHVyZSUyQyUyMGFuY2llbnQlMjBydWlucyUyQyUyMGNpdHlzY2FwZXMlMkMlMjBjdWx0dXJhbCUyMGhlcml0YWdlfGVufDB8fHx8MTc0NTQ0MjMyNnww&ixlib=rb-4.0.3&q=80&w=1300&h=500 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="grayscale photo of low angle view of building" loading="lazy" decoding="async" width="1300" height="500" />
         </picture>
       </a>
 
-      <h3><a href="/articles/roaming-roof-world-himalayas-guide.html">Roaming the Roof of the World: A Guide to the Himalayas</a></h3>
+      <h3><a href="/articles/timeless-timelines-history-iconic-landmarks.html">Timeless Timelines: Unraveling the History of Iconic Landmarks</a></h3>
 
       <div id="published">
         Published:
-        <em><time itemprop="datePublished" datetime="2025-04-14">
-            April 14, 2025</time></em>
+        <em><time itemprop="datePublished" datetime="2024-11-16">
+            November 16, 2024</time></em>
       </div>
 
-      <p>Nestled towering between the plains of India and the Tibetan Plateau, the Himalayas are a marvel of nature and culture. This guide offers insights into iconic trekking routes, local traditions, and travel essentials to help adventurers and explorers experience the grandeur of the world's highest mountain range.</p>
+      <p>Iconic landmarks serve as living testimonies to human history, culture, and innovation. They captivate travelers and historians alike, revealing stories of civilizations past and present. This guide explores the fascinating timelines behind these architectural marvels, offering a glimpse into their origins, transformations, and enduring allure that make them timeless symbols around the globe.</p>
     </div>
     <div class="card">
-      <a aria-label="body of water under sky" href="/articles/visit-earth-extremities.html">
+      <a aria-label="photo of two mountains" href="/articles/traveling-without-trace.html">
         <picture>
-          <img src="https://images.unsplash.com/photo-1518837695005-2083093ee35b?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxFYXJ0aCUyMGV4dHJlbWl0aWVzJTJDJTIwZ2VvZ3JhcGhpYyUyMHBvbGVzJTJDJTIwbm9ydGhlcm5tb3N0JTIwcG9pbnQlMkMlMjBzb3V0aGVybm1vc3QlMjBwb2ludCUyQyUyMGdsYWNpZXJzJTJDJTIwZGVzZXJ0cyUyQyUyMG1vdW50YWluJTIwcGVha3MlMkMlMjBvY2VhbnxlbnwwfHx8fDE3NDU0MTk4MzB8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500" srcset="https://images.unsplash.com/photo-1518837695005-2083093ee35b?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxFYXJ0aCUyMGV4dHJlbWl0aWVzJTJDJTIwZ2VvZ3JhcGhpYyUyMHBvbGVzJTJDJTIwbm9ydGhlcm5tb3N0JTIwcG9pbnQlMkMlMjBzb3V0aGVybm1vc3QlMjBwb2ludCUyQyUyMGdsYWNpZXJzJTJDJTIwZGVzZXJ0cyUyQyUyMG1vdW50YWluJTIwcGVha3MlMkMlMjBvY2VhbnxlbnwwfHx8fDE3NDU0MTk4MzB8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500&dpr=2 2x,
-                https://images.unsplash.com/photo-1518837695005-2083093ee35b?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxFYXJ0aCUyMGV4dHJlbWl0aWVzJTJDJTIwZ2VvZ3JhcGhpYyUyMHBvbGVzJTJDJTIwbm9ydGhlcm5tb3N0JTIwcG9pbnQlMkMlMjBzb3V0aGVybm1vc3QlMjBwb2ludCUyQyUyMGdsYWNpZXJzJTJDJTIwZGVzZXJ0cyUyQyUyMG1vdW50YWluJTIwcGVha3MlMkMlMjBvY2VhbnxlbnwwfHx8fDE3NDU0MTk4MzB8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="body of water under sky" loading="lazy" decoding="async" width="1300" height="500" />
+          <img src="https://images.unsplash.com/photo-1714188764655-f002141b25d1?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxuYXR1cmUlMjBjYW1waW5nJTIwaGlraW5nJTIwb3V0ZG9vciUyMGVjbyUyMGNvbnNlcnZhdGlvbnxlbnwwfHx8fDE3NDU0NDIzNjZ8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500" srcset="https://images.unsplash.com/photo-1714188764655-f002141b25d1?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxuYXR1cmUlMjBjYW1waW5nJTIwaGlraW5nJTIwb3V0ZG9vciUyMGVjbyUyMGNvbnNlcnZhdGlvbnxlbnwwfHx8fDE3NDU0NDIzNjZ8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500&dpr=2 2x,
+                https://images.unsplash.com/photo-1714188764655-f002141b25d1?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxuYXR1cmUlMjBjYW1waW5nJTIwaGlraW5nJTIwb3V0ZG9vciUyMGVjbyUyMGNvbnNlcnZhdGlvbnxlbnwwfHx8fDE3NDU0NDIzNjZ8MA&ixlib=rb-4.0.3&q=80&w=1300&h=500 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="photo of two mountains" loading="lazy" decoding="async" width="1300" height="500" />
         </picture>
       </a>
 
-      <h3><a href="/articles/visit-earth-extremities.html">A Visit to Earth’s Extremities: A Guide to Extreme Geographical Points</a></h3>
+      <h3><a href="/articles/traveling-without-trace.html">Traveling Without a Trace: A Guide to Leave No Trace Principles</a></h3>
 
       <div id="published">
         Published:
-        <em><time itemprop="datePublished" datetime="2025-03-02">
-            March 2, 2025</time></em>
+        <em><time itemprop="datePublished" datetime="2025-04-16">
+            April 16, 2025</time></em>
       </div>
 
-      <p>Earth's extremities reveal some of the most unique and breathtaking landscapes on our planet. From icy polar regions to scorching deserts, these points highlight the planet's diversity and grandeur. Embarking on a journey to these locations offers a rare glimpse into the planet’s geographic extremes and the wonders they hold. Join us as we explore the topmost and bottommost points of Earth and what makes each one extraordinary.</p>
+      <p>Embarking on outdoor adventures offers unparalleled connection with nature. By applying Leave No Trace principles, travelers can enjoy pristine environments while preserving them for others. This guide explores practical steps to minimize your footprint, promote sustainability, and ensure that natural spaces remain unspoiled for generations to come. Responsible travel begins with mindful habits and respectful behavior.</p>
     </div>
     <div class="card">
-      <a aria-label="trees on forest with sun rays" href="/articles/glamping-world-luxury-tents-incredible-views.html">
+      <a aria-label="person carrying yellow and black backpack walking between green plants" href="/articles/navigating-solo-journeys-travel-challenges-2025.html">
         <picture>
-          <img src="https://images.unsplash.com/photo-1448375240586-882707db888b?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxsdXh1cnklMjBjYW1waW5nJTIwdGVudHMlMjBtb3VudGFpbiUyMHZpZXclMjBmb3Jlc3QlMjBzY2VuaWMlMjBvdXRkb29yfGVufDB8fHx8MTc0NTQxOTkwOXww&ixlib=rb-4.0.3&q=80&w=1300&h=500" srcset="https://images.unsplash.com/photo-1448375240586-882707db888b?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxsdXh1cnklMjBjYW1waW5nJTIwdGVudHMlMjBtb3VudGFpbiUyMHZpZXclMjBmb3Jlc3QlMjBzY2VuaWMlMjBvdXRkb29yfGVufDB8fHx8MTc0NTQxOTkwOXww&ixlib=rb-4.0.3&q=80&w=1300&h=500&dpr=2 2x,
-                https://images.unsplash.com/photo-1448375240586-882707db888b?crop=entropy&cs=tinysrgb&fit=crop&auto=format&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxsdXh1cnklMjBjYW1waW5nJTIwdGVudHMlMjBtb3VudGFpbiUyMHZpZXclMjBmb3Jlc3QlMjBzY2VuaWMlMjBvdXRkb29yfGVufDB8fHx8MTc0NTQxOTkwOXww&ixlib=rb-4.0.3&q=80&w=1300&h=500 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="trees on forest with sun rays" loading="lazy" decoding="async" width="1300" height="500" />
+          <img src="https://images.unsplash.com/photo-1501555088652-021faa106b9b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxzb2xvJTIwdHJhdmVsZXJ8ZW58MHwwfHx8MTc1MTQ1MDQ3Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1501555088652-021faa106b9b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxzb2xvJTIwdHJhdmVsZXJ8ZW58MHwwfHx8MTc1MTQ1MDQ3Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1501555088652-021faa106b9b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxzb2xvJTIwdHJhdmVsZXJ8ZW58MHwwfHx8MTc1MTQ1MDQ3Mnww&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="person carrying yellow and black backpack walking between green plants" loading="lazy" decoding="async" width="1300" height="500" />
         </picture>
       </a>
 
-      <h3><a href="/articles/glamping-world-luxury-tents-incredible-views.html">Glamping Around the World: Luxury Tents and Incredible Views</a></h3>
+      <h3><a href="/articles/navigating-solo-journeys-travel-challenges-2025.html">Navigating Solo Journeys and Travel Challenges in 2025</a></h3>
 
       <div id="published">
         Published:
-        <em><time itemprop="datePublished" datetime="2025-03-25">
-            March 25, 2025</time></em>
+        <em><time itemprop="datePublished" datetime="2025-07-02">
+            July 2, 2025</time></em>
       </div>
 
-      <p>Embark on a journey into the luxurious side of camping known as glamping. From sweeping mountain vistas to serene forest retreats, discover how travelers are blending comfort with nature. This guide explores top glamping destinations worldwide, showcasing innovative tent designs and breathtaking landscapes that redefine outdoor adventures.</p>
+      <p>Solo travel in 2025 presents unique opportunities and challenges that require thoughtful preparation and awareness. This guide covers essential tips, safety priorities, layover optimization, and strategies for overcoming common travel obstacles to help you navigate your journey confidently.</p>
+    </div>
+    <div class="card">
+      <a aria-label="people gathering near the hut lot during daytime" href="/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html">
+        <picture>
+          <img src="https://images.unsplash.com/photo-1560643248-d9c6124b2a44?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3aW5kaW5nJTIwbW91bnRhaW4lMjByb2FkcyUyMHJlbW90ZSUyMHZpbGxhZ2UlMjBjdWx0dXJhbCUyMGZlc3RpdmFsfGVufDB8MHx8fDE3NTMxOTAwNzR8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1560643248-d9c6124b2a44?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3aW5kaW5nJTIwbW91bnRhaW4lMjByb2FkcyUyMHJlbW90ZSUyMHZpbGxhZ2UlMjBjdWx0dXJhbCUyMGZlc3RpdmFsfGVufDB8MHx8fDE3NTMxOTAwNzR8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1560643248-d9c6124b2a44?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHx3aW5kaW5nJTIwbW91bnRhaW4lMjByb2FkcyUyMHJlbW90ZSUyMHZpbGxhZ2UlMjBjdWx0dXJhbCUyMGZlc3RpdmFsfGVufDB8MHx8fDE3NTMxOTAwNzR8MA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="people gathering near the hut lot during daytime" loading="lazy" decoding="async" width="1300" height="500" />
+        </picture>
+      </a>
+
+      <h3><a href="/articles/navigating-global-travel-unique-destinations-challenges-cultural-insights.html">Navigating Global Travel: Unique Destinations, Challenges, and Cultural Insights</a></h3>
+
+      <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="2025-07-22">
+            July 22, 2025</time></em>
+      </div>
+
+      <p>Global travel invites explorers to venture beyond typical tourist spots, uncovering unique destinations rich in culture and challenge. This journey begins by exploring off-the-beaten-path locations that reveal authentic experiences and set the stage for meaningful adventures.</p>
+    </div>
+    <div class="card">
+      <a aria-label="a bus driving through a canyon" href="/articles/explore-enchanting-destinations-smart-travel-planning-2025.html">
+        <picture>
+          <img src="https://images.unsplash.com/photo-1669399554927-cc38ca6bc3ba?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlbmNoYW50aW5nJTIwdHJhdmVsJTIwZGVzdGluYXRpb25zJTIwMjAyNXxlbnwwfDB8fHwxNzU1MjYyODM2fDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300" srcset="https://images.unsplash.com/photo-1669399554927-cc38ca6bc3ba?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlbmNoYW50aW5nJTIwdHJhdmVsJTIwZGVzdGluYXRpb25zJTIwMjAyNXxlbnwwfDB8fHwxNzU1MjYyODM2fDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300&dpr=2 2x,
+                https://images.unsplash.com/photo-1669399554927-cc38ca6bc3ba?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3MzkyNTJ8MHwxfHNlYXJjaHwxfHxlbmNoYW50aW5nJTIwdHJhdmVsJTIwZGVzdGluYXRpb25zJTIwMjAyNXxlbnwwfDB8fHwxNzU1MjYyODM2fDA&ixlib=rb-4.1.0&q=80&w=1300?w=1300 1x" sizes="(min-width:38rem) 38rem, 100vw" alt="a bus driving through a canyon" loading="lazy" decoding="async" width="1300" height="500" />
+        </picture>
+      </a>
+
+      <h3><a href="/articles/explore-enchanting-destinations-smart-travel-planning-2025.html">Explore Enchanting Destinations and Smart Travel Planning Tips for 2025</a></h3>
+
+      <div id="published">
+        Published:
+        <em><time itemprop="datePublished" datetime="2025-08-15">
+            August 15, 2025</time></em>
+      </div>
+
+      <p>Discover the most enchanting travel destinations set to captivate adventurers in 2025, paired with smart planning tips to make every trip seamless. From unique locales to insider advice, this guide will inspire your next unforgettable journey.</p>
     </div>
       </section>
     </main>

--- a/scripts/update-image-seeds.mjs
+++ b/scripts/update-image-seeds.mjs
@@ -1,0 +1,21 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import crypto from 'node:crypto';
+
+const articlesDir = join(process.cwd(), 'articles');
+const files = (await readdir(articlesDir)).filter(f => f.endsWith('.html'));
+
+for (const file of files) {
+  const filePath = join(articlesDir, file);
+  let html = await readFile(filePath, 'utf8');
+  const replacements = {};
+  html = html.replace(/(https:\/\/picsum\.photos\/seed\/)([^\/]+)/g, (match, prefix, slug) => {
+    if (!replacements[slug]) {
+      const words = slug.split('-').slice(0, 4).join('-');
+      const seed = crypto.randomBytes(3).toString('hex');
+      replacements[slug] = `${words}-${seed}`;
+    }
+    return `${prefix}${replacements[slug]}`;
+  });
+  await writeFile(filePath, html);
+}


### PR DESCRIPTION
## Summary
- truncate Picsum image slugs to a maximum of four words and append a random seed.
- add script to update article image slugs automatically.
- regenerate latest and most-read articles to reflect new image URLs.

## Testing
- `node scripts/update-search-index.mjs`
- `node scripts/update-latest-posts.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b30c4516348329bdaed900dc404a7a