### PR TITLE
Fix sitemap update workflow failing due to missing HTML extension

### DIFF
--- a/.github/workflows/generate-sitemap.yml
+++ b/.github/workflows/generate-sitemap.yml
@@ -47,7 +47,7 @@ jobs:
               slug=$(basename "$html" .html)
               xmlstarlet ed -L \
                 -N sm="http://www.sitemaps.org/schemas/sitemap/0.9" \
-                -u "/sm:urlset/sm:url[sm:loc='https://exitfloridakeys.com/articles/$slug']/sm:lastmod" \
+                -u "/sm:urlset/sm:url[sm:loc='https://exitfloridakeys.com/articles/$slug.html']/sm:lastmod" \
                 -v "$datetime" \
                 sitemap.xml
             done


### PR DESCRIPTION
## Summary
- ensure sitemap update step targets URLs with `.html` extension

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3be85dc2883298d77972b0ae24879