### PR TITLE
chore: add workflow to refresh latest posts

### DIFF
--- a/.github/workflows/update-latest-posts.yml
+++ b/.github/workflows/update-latest-posts.yml
@@ -1,0 +1,34 @@
+name: update-latest-posts
+
+permissions:
+  contents: write
+
+on:
+  push:
+    paths:
+      - "articles/**"
+
+jobs:
+  latest-posts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Update latest posts
+        run: node scripts/update-latest-posts.mjs
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add index.html latest-articles.html most-read-articles.html
+          git commit -m "chore: update latest posts" || echo "No changes to commit"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to regenerate latest-posts section and commit updated pages when articles change

## Testing
- `node scripts/update-latest-posts.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68b3dd0e9b388329b9015722803ae2af