### PR TITLE
feat: skip figure insertion when article has two images

### DIFF
--- a/scripts/inject-secondary-figures.mjs
+++ b/scripts/inject-secondary-figures.mjs
@@ -31,6 +31,12 @@ for (const file of files) {
   const bound = asideIndex !== -1 ? asideIndex : (articleEndIndex !== -1 ? articleEndIndex : html.length);
   const articleContent = html.slice(articleStart, bound);
 
+  // Count existing figures in the article body (skip header and sidebar)
+  const headerEnd = articleContent.indexOf("</header>");
+  const articleBody = headerEnd !== -1 ? articleContent.slice(headerEnd) : articleContent;
+  const figureCount = (articleBody.match(/<figure/gi) || []).length;
+  if (figureCount >= 2) continue;
+
   // Skip if the placeholder image for this slug already exists
   if (articleContent.includes("picsum.photos/seed/" + slug)) continue;
 


### PR DESCRIPTION
## Summary
- Count existing figures in article body and skip if two or more already present
- Avoid unnecessary placeholder figures when posts already include multiple images

## Testing
- `rg -c "<figure" articles/chasing-northern-lights-best-places.html`
- `node scripts/inject-secondary-figures.mjs`
- `rg -c "<figure" articles/chasing-northern-lights-best-places.html`


------
https://chatgpt.com/codex/tasks/task_e_68b3e0964d24832981de7c7adc5944e5