### PR TITLE
fix: ensure consistent Travel Guide naming

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -88,7 +88,7 @@
         <p>
           Founded by a collective of passionate travelers, writers, and editors,
           we believe every journey tells a story. Whether you’re planning your
-          next big adventure or looking for hidden gems closer to home, Audio
+          next big adventure or looking for hidden gems closer to home,
           Travel Guide is here to guide you every step of the way.
         </p>
       </section>


### PR DESCRIPTION
## Summary
- fix inconsistent naming in about-us intro by replacing 'Audio Travel Guide' with 'Travel Guide'

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c111cff6448329a19655e526a7e4e5